### PR TITLE
Disable `CooldownPeriod`

### DIFF
--- a/Apollo11.py
+++ b/Apollo11.py
@@ -54,7 +54,7 @@ class Apollo11(IStrategy):
             {
                 # Don't enter a trade right after selling a trade.
                 "method": "CooldownPeriod",
-                "stop_duration": to_minutes(hours=1, minutes=15),
+                "stop_duration": to_minutes(minutes=0),
             },
             {
                 # Stop trading if max-drawdown is reached.


### PR DESCRIPTION
``Apollo11_2`` has the cooldown period changes.

# Setting ``CooldownPeriod`` to 15 minutes
```
Result for strategy Apollo11
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|   AERGO/BUSD |     45 |           2.22 |          99.95 |           150.076 |          15.01 |         20:27:00 |    41     0     4  91.1 |
|     AVA/BUSD |     20 |           3.71 |          74.25 |           111.480 |          11.15 |   1 day, 6:12:00 |    20     0     0   100 |
|     ANT/BUSD |     24 |           2.97 |          71.38 |           107.177 |          10.72 |   1 day, 5:16:00 |    23     0     1  95.8 |
|    DEXE/BUSD |     36 |           1.89 |          67.89 |           101.938 |          10.19 |   1 day, 7:59:00 |    31     0     5  86.1 |
|    HARD/BUSD |     16 |           3.99 |          63.78 |            95.762 |           9.58 |         12:05:00 |    16     0     0   100 |
|   ALPHA/BUSD |     35 |           1.76 |          61.69 |            92.630 |           9.26 |         16:27:00 |    32     0     3  91.4 |
|   CREAM/BUSD |     32 |           1.89 |          60.63 |            91.030 |           9.10 |  1 day, 23:39:00 |    28     0     4  87.5 |
|     DOT/BUSD |     16 |           3.65 |          58.38 |            87.654 |           8.77 |         14:49:00 |    16     0     0   100 |
|     BEL/BUSD |     22 |           2.55 |          56.00 |            84.081 |           8.41 |         17:58:00 |    21     0     1  95.5 |
|     PHA/BUSD |     11 |           5.08 |          55.86 |            83.875 |           8.39 |   1 day, 2:41:00 |    11     0     0   100 |
|     AXS/BUSD |     20 |           2.70 |          53.91 |            80.939 |           8.09 |         12:13:00 |    18     0     2  90.0 |
|     ATA/BUSD |     13 |           3.96 |          51.46 |            77.268 |           7.73 |  1 day, 10:27:00 |    12     0     1  92.3 |
|     LIT/BUSD |     11 |           4.11 |          45.19 |            67.857 |           6.79 |         20:46:00 |    11     0     0   100 |
|     UFT/BUSD |     11 |           3.76 |          41.32 |            62.045 |           6.20 |         10:14:00 |    11     0     0   100 |
|     INJ/BUSD |     12 |           3.30 |          39.62 |            59.490 |           5.95 |         10:48:00 |    11     0     1  91.7 |
|     DGB/BUSD |     18 |           2.17 |          39.01 |            58.575 |           5.86 |   1 day, 0:00:00 |    17     0     1  94.4 |
|      AR/BUSD |     14 |           2.78 |          38.93 |            58.453 |           5.85 |         11:59:00 |    13     0     1  92.9 |
|    BAND/BUSD |     10 |           3.55 |          35.48 |            53.270 |           5.33 |  2 days, 7:36:00 |    10     0     0   100 |
|    LINA/BUSD |      7 |           4.49 |          31.45 |            47.224 |           4.72 |         11:26:00 |     7     0     0   100 |
|     TKO/BUSD |      5 |           6.23 |          31.15 |            46.774 |           4.68 |   1 day, 4:27:00 |     5     0     0   100 |
|    NEAR/BUSD |      9 |           3.40 |          30.57 |            45.905 |           4.59 |         18:22:00 |     9     0     0   100 |
|    DODO/BUSD |      9 |           3.33 |          29.94 |            44.950 |           4.49 |         12:28:00 |     9     0     0   100 |
|    ALGO/BUSD |     31 |           0.95 |          29.49 |            44.283 |           4.43 |   1 day, 2:20:00 |    27     0     4  87.1 |
|    RUNE/BUSD |     12 |           2.27 |          27.29 |            40.983 |           4.10 |         18:08:00 |    11     0     1  91.7 |
|    CTSI/BUSD |     12 |           2.21 |          26.51 |            39.805 |           3.98 |  2 days, 4:50:00 |    11     0     1  91.7 |
|     LTC/BUSD |      9 |           2.93 |          26.38 |            39.608 |           3.96 |  2 days, 7:12:00 |     9     0     0   100 |
|     CRV/BUSD |     25 |           0.91 |          22.83 |            34.280 |           3.43 |  1 day, 11:26:00 |    22     0     3  88.0 |
|     WRX/BUSD |      3 |           7.55 |          22.64 |            33.994 |           3.40 |          2:10:00 |     3     0     0   100 |
|    LINK/BUSD |      6 |           3.14 |          18.86 |            28.319 |           2.83 |         22:38:00 |     6     0     0   100 |
|     XRP/BUSD |      5 |           3.55 |          17.74 |            26.636 |           2.66 |   1 day, 4:03:00 |     5     0     0   100 |
|   OCEAN/BUSD |      6 |           2.91 |          17.47 |            26.228 |           2.62 |          4:18:00 |     6     0     0   100 |
|    SAND/BUSD |      9 |           1.94 |          17.46 |            26.209 |           2.62 |   1 day, 1:13:00 |     8     0     1  88.9 |
|     SFP/BUSD |      6 |           2.88 |          17.30 |            25.969 |           2.60 |          3:40:00 |     6     0     0   100 |
|    PROM/BUSD |     24 |           0.71 |          17.13 |            25.725 |           2.57 |  1 day, 18:24:00 |    21     0     3  87.5 |
|   AUDIO/BUSD |     28 |           0.60 |          16.76 |            25.173 |           2.52 |  1 day, 11:19:00 |    24     0     4  85.7 |
|    ATOM/BUSD |     20 |           0.83 |          16.58 |            24.889 |           2.49 |         21:45:00 |    17     0     3  85.0 |
|     ONE/BUSD |     13 |           1.19 |          15.42 |            23.157 |           2.32 |         15:09:00 |    11     0     2  84.6 |
|    PERP/BUSD |     10 |           1.30 |          12.96 |            19.453 |           1.95 |         11:10:00 |     9     0     1  90.0 |
|    STMX/BUSD |      3 |           3.82 |          11.45 |            17.191 |           1.72 |         14:55:00 |     3     0     0   100 |
|    LUNA/BUSD |     19 |           0.59 |          11.17 |            16.778 |           1.68 |  1 day, 19:02:00 |    16     0     3  84.2 |
|     FTM/BUSD |      3 |           3.66 |          10.98 |            16.488 |           1.65 |  1 day, 14:20:00 |     3     0     0   100 |
|   WAVES/BUSD |      4 |           2.73 |          10.92 |            16.403 |           1.64 |          9:34:00 |     4     0     0   100 |
|      IQ/BUSD |     18 |           0.58 |          10.43 |            15.667 |           1.57 |         20:00:00 |    16     0     2  88.9 |
|     TWT/BUSD |      3 |           3.38 |          10.13 |            15.216 |           1.52 |         12:55:00 |     3     0     0   100 |
|    KEEP/BUSD |      3 |           3.37 |          10.11 |            15.175 |           1.52 |  3 days, 2:25:00 |     3     0     0   100 |
|    AAVE/BUSD |     27 |           0.33 |           8.86 |            13.303 |           1.33 |  1 day, 13:13:00 |    23     0     4  85.2 |
| AUCTION/BUSD |     16 |           0.49 |           7.80 |            11.708 |           1.17 |         18:22:00 |    14     0     2  87.5 |
|    BZRX/BUSD |     16 |           0.43 |           6.95 |            10.433 |           1.04 |         10:27:00 |    13     0     3  81.2 |
|     ZEC/BUSD |      2 |           3.12 |           6.23 |             9.360 |           0.94 |          2:38:00 |     2     0     0   100 |
|   SUSHI/BUSD |      7 |           0.84 |           5.86 |             8.805 |           0.88 |   1 day, 2:39:00 |     6     0     1  85.7 |
|    SHIB/BUSD |      1 |           5.83 |           5.83 |             8.750 |           0.88 |  1 day, 12:30:00 |     1     0     0   100 |
|    REEF/BUSD |      7 |           0.67 |           4.67 |             7.013 |           0.70 |         16:24:00 |     6     0     1  85.7 |
|   SUPER/BUSD |      8 |           0.54 |           4.33 |             6.505 |           0.65 |   1 day, 6:00:00 |     7     0     1  87.5 |
|     XVG/BUSD |      1 |           3.92 |           3.92 |             5.890 |           0.59 |          0:30:00 |     1     0     0   100 |
|     BTT/BUSD |      8 |           0.46 |           3.70 |             5.562 |           0.56 |         22:15:00 |     7     0     1  87.5 |
|    IOST/BUSD |      7 |           0.41 |           2.84 |             4.257 |           0.43 |          5:09:00 |     6     0     1  85.7 |
|     SKL/BUSD |      7 |           0.24 |           1.68 |             2.521 |           0.25 |         20:30:00 |     6     0     1  85.7 |
|     FIO/BUSD |     18 |           0.06 |           1.13 |             1.695 |           0.17 |   1 day, 8:47:00 |    15     0     3  83.3 |
|     KNC/BUSD |      8 |           0.12 |           0.92 |             1.389 |           0.14 |   1 day, 1:04:00 |     7     0     1  87.5 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FIL/BUSD |     17 |          -0.02 |          -0.38 |            -0.573 |          -0.06 |  1 day, 10:52:00 |    14     0     3  82.4 |
|    POND/BUSD |      8 |          -0.12 |          -0.95 |            -1.429 |          -0.14 |         18:02:00 |     7     0     1  87.5 |
|    BAKE/BUSD |     18 |          -0.08 |          -1.46 |            -2.195 |          -0.22 |  1 day, 10:29:00 |    15     0     3  83.3 |
|     SXP/BUSD |      7 |          -0.31 |          -2.18 |            -3.279 |          -0.33 |         15:04:00 |     6     0     1  85.7 |
|    NANO/BUSD |      9 |          -0.28 |          -2.52 |            -3.787 |          -0.38 |  1 day, 23:05:00 |     7     0     2  77.8 |
|   1INCH/BUSD |     14 |          -0.21 |          -2.92 |            -4.386 |          -0.44 |         19:14:00 |    12     0     2  85.7 |
|     CTK/BUSD |     10 |          -0.39 |          -3.90 |            -5.861 |          -0.59 |  1 day, 20:46:00 |     8     0     2  80.0 |
|   FRONT/BUSD |     22 |          -0.20 |          -4.50 |            -6.754 |          -0.68 |   1 day, 4:01:00 |    17     0     5  77.3 |
|    POLS/BUSD |      5 |          -0.92 |          -4.60 |            -6.910 |          -0.69 |   1 day, 5:06:00 |     4     0     1  80.0 |
|     XTZ/BUSD |      6 |          -0.81 |          -4.84 |            -7.267 |          -0.73 |  1 day, 13:08:00 |     5     0     1  83.3 |
|    DASH/BUSD |     13 |          -0.46 |          -6.02 |            -9.036 |          -0.90 |         23:32:00 |    11     0     2  84.6 |
|    DOCK/BUSD |      5 |          -1.25 |          -6.27 |            -9.415 |          -0.94 |   1 day, 7:30:00 |     4     0     1  80.0 |
|     GTC/BUSD |      4 |          -1.74 |          -6.97 |           -10.464 |          -1.05 |  2 days, 5:00:00 |     3     0     1  75.0 |
|     RSR/BUSD |      9 |          -0.87 |          -7.81 |           -11.726 |          -1.17 |   1 day, 2:02:00 |     7     0     2  77.8 |
|     ZIL/BUSD |      4 |          -2.02 |          -8.08 |           -12.134 |          -1.21 |         10:41:00 |     3     0     1  75.0 |
|    IOTX/BUSD |      4 |          -2.04 |          -8.15 |           -12.240 |          -1.22 |         20:00:00 |     3     0     1  75.0 |
|     MIR/BUSD |     12 |          -0.69 |          -8.25 |           -12.386 |          -1.24 | 2 days, 19:54:00 |     9     0     3  75.0 |
|     KSM/BUSD |     13 |          -0.71 |          -9.20 |           -13.811 |          -1.38 |         14:58:00 |    11     0     2  84.6 |
|     YFI/BUSD |      4 |          -2.40 |          -9.59 |           -14.400 |          -1.44 |  1 day, 21:08:00 |     3     0     1  75.0 |
|     TVK/BUSD |      4 |          -2.44 |          -9.76 |           -14.659 |          -1.47 |   1 day, 2:19:00 |     3     0     1  75.0 |
|    EGLD/BUSD |     17 |          -0.60 |         -10.17 |           -15.272 |          -1.53 |  1 day, 10:55:00 |    14     0     3  82.4 |
|     SOL/BUSD |      4 |          -2.56 |         -10.25 |           -15.392 |          -1.54 | 2 days, 16:30:00 |     3     0     1  75.0 |
|     SRM/BUSD |      4 |          -2.59 |         -10.38 |           -15.580 |          -1.56 |  1 day, 20:00:00 |     3     0     1  75.0 |
|    COTI/BUSD |      3 |          -3.66 |         -10.99 |           -16.500 |          -1.65 |   1 day, 8:45:00 |     2     0     1  66.7 |
|    IDEX/BUSD |      8 |          -1.44 |         -11.52 |           -17.301 |          -1.73 | 2 days, 11:52:00 |     6     0     2  75.0 |
|    MANA/BUSD |     10 |          -1.25 |         -12.55 |           -18.840 |          -1.88 |  1 day, 23:22:00 |     8     0     2  80.0 |
|     SNX/BUSD |      3 |          -4.93 |         -14.79 |           -22.211 |          -2.22 |   1 day, 7:55:00 |     2     0     1  66.7 |
|     ICP/BUSD |      8 |          -1.90 |         -15.22 |           -22.860 |          -2.29 |   1 day, 1:09:00 |     6     0     2  75.0 |
|     GRT/BUSD |      7 |          -2.19 |         -15.31 |           -22.986 |          -2.30 |  2 days, 7:06:00 |     5     0     2  71.4 |
|     CVP/BUSD |     18 |          -0.95 |         -17.15 |           -25.752 |          -2.58 |  1 day, 21:50:00 |    14     0     4  77.8 |
|    AVAX/BUSD |     17 |          -1.19 |         -20.30 |           -30.478 |          -3.05 |         17:26:00 |    14     0     3  82.4 |
|   MATIC/BUSD |     10 |          -2.10 |         -21.02 |           -31.560 |          -3.16 |         21:48:00 |     7     0     3  70.0 |
|     UNI/BUSD |      8 |          -2.92 |         -23.32 |           -35.018 |          -3.50 |  2 days, 4:06:00 |     6     0     2  75.0 |
|     HOT/BUSD |      6 |          -4.46 |         -26.77 |           -40.188 |          -4.02 |  1 day, 10:32:00 |     4     0     2  66.7 |
|     MKR/BUSD |     12 |          -2.23 |         -26.81 |           -40.250 |          -4.02 | 3 days, 16:39:00 |     9     0     3  75.0 |
|     EPS/BUSD |     11 |          -2.76 |         -30.36 |           -45.584 |          -4.56 |         21:00:00 |     8     0     3  72.7 |
|     MDX/BUSD |      5 |          -6.33 |         -31.67 |           -47.557 |          -4.76 |  4 days, 6:12:00 |     3     0     2  60.0 |
|     ENJ/BUSD |     17 |          -1.88 |         -32.03 |           -48.087 |          -4.81 |         19:24:00 |    13     0     4  76.5 |
|     BCH/BUSD |     18 |          -1.81 |         -32.51 |           -48.812 |          -4.88 |  1 day, 16:49:00 |    14     0     4  77.8 |
|   FORTH/BUSD |      9 |          -3.74 |         -33.70 |           -50.596 |          -5.06 |   1 day, 8:17:00 |     6     0     3  66.7 |
|    DEGO/BUSD |     10 |          -3.88 |         -38.80 |           -58.260 |          -5.83 |  1 day, 22:56:00 |     7     0     3  70.0 |
|    DATA/BUSD |     17 |          -2.44 |         -41.55 |           -62.394 |          -6.24 |  1 day, 21:33:00 |    10     0     7  58.8 |
|   ALICE/BUSD |     16 |          -2.76 |         -44.18 |           -66.337 |          -6.63 |   1 day, 5:34:00 |    12     0     4  75.0 |
|     TLM/BUSD |      7 |          -6.56 |         -45.95 |           -69.000 |          -6.90 |         15:54:00 |     4     0     3  57.1 |
|    COMP/BUSD |     24 |          -2.64 |         -63.47 |           -95.303 |          -9.53 |  1 day, 13:01:00 |    18     0     6  75.0 |
|     XVS/BUSD |     17 |          -4.26 |         -72.47 |          -108.815 |         -10.88 |         12:53:00 |    11     0     6  64.7 |
|    DOGE/BUSD |     22 |          -3.63 |         -79.77 |          -119.776 |         -11.98 |  1 day, 23:35:00 |    15     0     7  68.2 |
|     FXS/BUSD |     22 |          -5.08 |        -111.83 |          -167.914 |         -16.79 |  2 days, 8:45:00 |    14     0     8  63.6 |
|        TOTAL |   1319 |           0.45 |         587.37 |           881.941 |          88.19 |   1 day, 6:03:00 |  1120     0   199  84.9 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |    1120 |   1120     0     0   100 |           4.04 |        4525.24 |           6794.64 |         754.21 |
|          stop_loss |     193 |      0     0   193     0 |         -20.16 |       -3891.2  |          -5842.64 |        -648.53 |
|         force_sell |       6 |      0     0     6     0 |          -7.78 |         -46.66 |            -70.06 |          -7.78 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|  ATOM/BUSD |      1 |          -3.78 |          -3.78 |            -5.674 |          -0.57 |  3 days, 0:00:00 |     0     0     1     0 |
| CREAM/BUSD |      1 |          -5.36 |          -5.36 |            -8.042 |          -0.80 |  9 days, 9:00:00 |     0     0     1     0 |
| FRONT/BUSD |      1 |          -7.50 |          -7.50 |           -11.262 |          -1.13 | 5 days, 21:15:00 |     0     0     1     0 |
|  ALGO/BUSD |      1 |          -8.94 |          -8.94 |           -13.425 |          -1.34 |  2 days, 4:00:00 |     0     0     1     0 |
| ALPHA/BUSD |      1 |          -9.52 |          -9.52 |           -14.289 |          -1.43 | 2 days, 23:30:00 |     0     0     1     0 |
|   BEL/BUSD |      1 |         -11.57 |         -11.57 |           -17.369 |          -1.74 |  4 days, 4:00:00 |     0     0     1     0 |
|      TOTAL |      6 |          -7.78 |         -46.66 |           -70.060 |          -7.01 | 4 days, 14:18:00 |     0     0     6     0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-01-01 00:00:00 |
| Backtesting to         | 2021-10-12 15:45:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 1319 / 4.64         |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1881.941 BUSD       |
| Absolute profit        | 881.941 BUSD        |
| Total profit %         | 88.19%              |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 197850.000 BUSD     |
|                        |                     |
| Best Pair              | AERGO/BUSD 99.95%   |
| Worst Pair             | FXS/BUSD -111.83%   |
| Best trade             | DATA/BUSD 55.16%    |
| Worst trade            | CVP/BUSD -20.48%    |
| Best day               | 185.423 BUSD        |
| Worst day              | -258.466 BUSD       |
| Days win/draw/lose     | 185 / 30 / 70       |
| Avg. Duration Winners  | 22:46:00            |
| Avg. Duration Loser    | 2 days, 23:01:00    |
| Rejected Buy signals   | 2203320             |
|                        |                     |
| Min balance            | 1004.209 BUSD       |
| Max balance            | 2060.573 BUSD       |
| Drawdown               | 597.06%             |
| Drawdown               | 896.479 BUSD        |
| Drawdown high          | 1060.573 BUSD       |
| Drawdown low           | 164.094 BUSD        |
| Drawdown Start         | 2021-02-20 13:45:00 |
| Drawdown End           | 2021-06-22 14:00:00 |
| Market change          | 759.59%             |
================================================

Result for strategy Apollo11_2
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|   ALPHA/BUSD |     37 |           2.61 |          96.65 |           145.116 |          14.51 |         14:46:00 |    35     0     2  94.6 |
|   AERGO/BUSD |     47 |           2.03 |          95.45 |           143.316 |          14.33 |         17:49:00 |    43     0     4  91.5 |
|    DEXE/BUSD |     45 |           2.01 |          90.63 |           136.079 |          13.61 |   1 day, 6:42:00 |    39     0     6  86.7 |
|     AVA/BUSD |     23 |           3.64 |          83.80 |           125.823 |          12.58 |         20:52:00 |    23     0     0   100 |
|    HARD/BUSD |     19 |           3.63 |          68.99 |           103.584 |          10.36 |         10:57:00 |    19     0     0   100 |
|     ANT/BUSD |     24 |           2.74 |          65.75 |            98.731 |           9.87 |  1 day, 14:48:00 |    22     0     2  91.7 |
| AUCTION/BUSD |     24 |           2.65 |          63.68 |            95.618 |           9.56 |         21:13:00 |    23     0     1  95.8 |
|     BEL/BUSD |     24 |           2.64 |          63.34 |            95.111 |           9.51 |         16:51:00 |    23     0     1  95.8 |
|   CREAM/BUSD |     34 |           1.86 |          63.31 |            95.066 |           9.51 |   1 day, 3:22:00 |    30     0     4  88.2 |
|      AR/BUSD |     14 |           4.31 |          60.34 |            90.595 |           9.06 |          8:20:00 |    14     0     0   100 |
|     ATA/BUSD |     13 |           4.44 |          57.75 |            86.709 |           8.67 |         23:13:00 |    12     0     1  92.3 |
|     LTC/BUSD |     11 |           4.87 |          53.59 |            80.473 |           8.05 |  1 day, 21:29:00 |    11     0     0   100 |
|     PHA/BUSD |     13 |           3.45 |          44.88 |            67.383 |           6.74 |         21:44:00 |    12     0     1  92.3 |
|    COTI/BUSD |      4 |           9.16 |          36.65 |            55.033 |           5.50 |   1 day, 2:38:00 |     3     0     1  75.0 |
|     AXS/BUSD |     17 |           2.15 |          36.62 |            54.979 |           5.50 |          9:34:00 |    15     0     2  88.2 |
|    LUNA/BUSD |     16 |           2.22 |          35.59 |            53.434 |           5.34 |  1 day, 20:05:00 |    14     0     2  87.5 |
|    LINA/BUSD |      8 |           4.24 |          33.96 |            50.985 |           5.10 |         11:22:00 |     8     0     0   100 |
|     WRX/BUSD |      5 |           6.18 |          30.91 |            46.406 |           4.64 |         19:48:00 |     5     0     0   100 |
|     DOT/BUSD |     15 |           2.06 |          30.86 |            46.336 |           4.63 |          9:47:00 |    14     0     1  93.3 |
|     LIT/BUSD |      7 |           4.34 |          30.35 |            45.576 |           4.56 |          8:34:00 |     7     0     0   100 |
|     BTT/BUSD |      8 |           3.59 |          28.69 |            43.075 |           4.31 |          9:00:00 |     8     0     0   100 |
|    BAND/BUSD |      9 |           3.10 |          27.87 |            41.845 |           4.18 |  1 day, 11:23:00 |     8     0     1  88.9 |
|   SUSHI/BUSD |      8 |           3.45 |          27.62 |            41.476 |           4.15 |         13:19:00 |     8     0     0   100 |
|     INJ/BUSD |     10 |           2.60 |          25.99 |            39.022 |           3.90 |         10:33:00 |     9     0     1  90.0 |
|    NEAR/BUSD |      7 |           3.45 |          24.18 |            36.314 |           3.63 |         22:56:00 |     7     0     0   100 |
|    LINK/BUSD |      6 |           3.95 |          23.67 |            35.546 |           3.55 |         15:42:00 |     6     0     0   100 |
|    SAND/BUSD |     11 |           2.01 |          22.16 |            33.275 |           3.33 |         21:44:00 |    10     0     1  90.9 |
|   OCEAN/BUSD |      7 |           3.09 |          21.63 |            32.480 |           3.25 |          7:02:00 |     7     0     0   100 |
|    NANO/BUSD |      7 |           3.06 |          21.42 |            32.163 |           3.22 |  1 day, 10:32:00 |     6     0     1  85.7 |
|     XRP/BUSD |      6 |           3.55 |          21.32 |            32.012 |           3.20 |  4 days, 2:12:00 |     6     0     0   100 |
|    IOST/BUSD |      5 |           4.22 |          21.11 |            31.692 |           3.17 |          2:45:00 |     5     0     0   100 |
|    DODO/BUSD |      5 |           4.00 |          20.01 |            30.052 |           3.01 |  1 day, 16:21:00 |     5     0     0   100 |
|    CTSI/BUSD |     13 |           1.53 |          19.88 |            29.845 |           2.98 |         16:27:00 |    12     0     1  92.3 |
|    IDEX/BUSD |      9 |           2.06 |          18.50 |            27.772 |           2.78 |  1 day, 23:08:00 |     8     0     1  88.9 |
|    PERP/BUSD |      9 |           2.05 |          18.43 |            27.673 |           2.77 |         16:05:00 |     8     0     1  88.9 |
|     UFT/BUSD |      9 |           2.03 |          18.24 |            27.393 |           2.74 |         18:07:00 |     8     0     1  88.9 |
|   1INCH/BUSD |     18 |           0.99 |          17.76 |            26.664 |           2.67 |          9:02:00 |    16     0     2  88.9 |
|     TKO/BUSD |      5 |           3.55 |          17.75 |            26.651 |           2.67 |   1 day, 4:30:00 |     5     0     0   100 |
|     FIL/BUSD |     20 |           0.81 |          16.15 |            24.244 |           2.42 |  2 days, 0:57:00 |    17     0     3  85.0 |
|   AUDIO/BUSD |     29 |           0.53 |          15.43 |            23.164 |           2.32 |  1 day, 17:20:00 |    25     0     4  86.2 |
|    ATOM/BUSD |     19 |           0.76 |          14.50 |            21.777 |           2.18 |         22:21:00 |    17     0     2  89.5 |
|    POND/BUSD |      5 |           2.87 |          14.34 |            21.527 |           2.15 |   1 day, 0:15:00 |     5     0     0   100 |
|    DATA/BUSD |     21 |           0.67 |          14.15 |            21.240 |           2.12 |  1 day, 11:15:00 |    16     0     5  76.2 |
|     FTM/BUSD |      4 |           3.34 |          13.36 |            20.063 |           2.01 |   1 day, 5:26:00 |     4     0     0   100 |
|   WAVES/BUSD |      4 |           3.07 |          12.27 |            18.425 |           1.84 |          9:49:00 |     4     0     0   100 |
|     RSR/BUSD |      8 |           1.50 |          12.03 |            18.063 |           1.81 |         14:49:00 |     7     0     1  87.5 |
|    ALGO/BUSD |     37 |           0.30 |          10.95 |            16.441 |           1.64 |         23:24:00 |    32     0     5  86.5 |
|     MIR/BUSD |     11 |           0.93 |          10.21 |            15.335 |           1.53 |  3 days, 3:59:00 |     9     0     2  81.8 |
|    AVAX/BUSD |     20 |           0.49 |           9.84 |            14.779 |           1.48 |         12:00:00 |    18     0     2  90.0 |
|     ZEC/BUSD |      3 |           3.01 |           9.03 |            13.559 |           1.36 |         11:30:00 |     3     0     0   100 |
|     MKR/BUSD |     11 |           0.56 |           6.13 |             9.210 |           0.92 | 3 days, 13:19:00 |     9     0     2  81.8 |
|     ICP/BUSD |      8 |           0.69 |           5.54 |             8.321 |           0.83 |         13:49:00 |     7     0     1  87.5 |
|     KSM/BUSD |     18 |           0.24 |           4.28 |             6.426 |           0.64 |         11:36:00 |    16     0     2  88.9 |
|    STMX/BUSD |      2 |           2.11 |           4.22 |             6.341 |           0.63 | 4 days, 17:45:00 |     2     0     0   100 |
|    REEF/BUSD |      6 |           0.68 |           4.08 |             6.125 |           0.61 |   1 day, 3:32:00 |     5     0     1  83.3 |
|     XVG/BUSD |      1 |           3.92 |           3.92 |             5.890 |           0.59 |          0:30:00 |     1     0     0   100 |
|    IOTX/BUSD |      7 |           0.50 |           3.52 |             5.282 |           0.53 |   1 day, 7:39:00 |     6     0     1  85.7 |
|    SHIB/BUSD |      1 |           2.43 |           2.43 |             3.648 |           0.36 |          3:15:00 |     1     0     0   100 |
|   MATIC/BUSD |      7 |           0.32 |           2.21 |             3.321 |           0.33 |         11:11:00 |     6     0     1  85.7 |
|    PROM/BUSD |     22 |           0.10 |           2.11 |             3.166 |           0.32 |  1 day, 16:44:00 |    19     0     3  86.4 |
|     KNC/BUSD |      8 |           0.25 |           2.03 |             3.041 |           0.30 |   1 day, 1:00:00 |     7     0     1  87.5 |
|    BZRX/BUSD |     14 |           0.10 |           1.45 |             2.173 |           0.22 |          5:42:00 |    12     0     2  85.7 |
|     DGB/BUSD |     17 |           0.07 |           1.24 |             1.856 |           0.19 |  1 day, 18:45:00 |    15     0     2  88.2 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     UNI/BUSD |      5 |          -0.04 |          -0.18 |            -0.271 |          -0.03 |   1 day, 9:42:00 |     3     0     2  60.0 |
|    RUNE/BUSD |     11 |          -0.03 |          -0.29 |            -0.431 |          -0.04 |   1 day, 5:12:00 |     9     0     2  81.8 |
|     SXP/BUSD |      8 |          -0.06 |          -0.44 |            -0.666 |          -0.07 |          9:52:00 |     7     0     1  87.5 |
|     TWT/BUSD |      6 |          -0.15 |          -0.92 |            -1.376 |          -0.14 |          8:05:00 |     5     0     1  83.3 |
|     ZIL/BUSD |      6 |          -0.29 |          -1.76 |            -2.646 |          -0.26 |          9:00:00 |     5     0     1  83.3 |
|     SOL/BUSD |      7 |          -0.32 |          -2.22 |            -3.328 |          -0.33 |   1 day, 8:49:00 |     6     0     1  85.7 |
|    EGLD/BUSD |     18 |          -0.19 |          -3.50 |            -5.249 |          -0.52 |   1 day, 5:54:00 |    15     0     3  83.3 |
|    POLS/BUSD |      5 |          -0.92 |          -4.60 |            -6.910 |          -0.69 |   1 day, 5:06:00 |     4     0     1  80.0 |
|    KEEP/BUSD |      4 |          -1.30 |          -5.19 |            -7.786 |          -0.78 | 2 days, 23:56:00 |     3     0     1  75.0 |
|    DEGO/BUSD |     12 |          -0.44 |          -5.31 |            -7.973 |          -0.80 |  2 days, 0:32:00 |    10     0     2  83.3 |
|     SNX/BUSD |      6 |          -0.91 |          -5.43 |            -8.158 |          -0.82 |         19:35:00 |     5     0     1  83.3 |
|     SKL/BUSD |      9 |          -0.68 |          -6.12 |            -9.197 |          -0.92 |   1 day, 0:08:00 |     7     0     2  77.8 |
|     SRM/BUSD |      5 |          -1.25 |          -6.23 |            -9.358 |          -0.94 |  1 day, 18:09:00 |     4     0     1  80.0 |
|    BAKE/BUSD |     16 |          -0.45 |          -7.25 |           -10.879 |          -1.09 |   1 day, 1:38:00 |    13     0     3  81.2 |
|     XTZ/BUSD |      5 |          -1.63 |          -8.15 |           -12.240 |          -1.22 |         18:06:00 |     4     0     1  80.0 |
|    DOCK/BUSD |      4 |          -2.10 |          -8.40 |           -12.609 |          -1.26 |  1 day, 12:56:00 |     3     0     1  75.0 |
|    MANA/BUSD |     11 |          -0.84 |          -9.22 |           -13.849 |          -1.38 |  1 day, 19:46:00 |     9     0     2  81.8 |
|   FRONT/BUSD |     20 |          -0.46 |          -9.28 |           -13.933 |          -1.39 |   1 day, 4:52:00 |    15     0     5  75.0 |
|     YFI/BUSD |      4 |          -2.42 |          -9.67 |           -14.523 |          -1.45 |  5 days, 3:34:00 |     3     0     1  75.0 |
|     HOT/BUSD |     10 |          -1.63 |         -16.32 |           -24.510 |          -2.45 |         15:00:00 |     8     0     2  80.0 |
|   ALICE/BUSD |     17 |          -0.99 |         -16.83 |           -25.275 |          -2.53 |         20:34:00 |    14     0     3  82.4 |
|     CTK/BUSD |     13 |          -1.32 |         -17.21 |           -25.834 |          -2.58 |  1 day, 11:05:00 |    10     0     3  76.9 |
|     CRV/BUSD |     20 |          -0.87 |         -17.46 |           -26.211 |          -2.62 |  1 day, 16:10:00 |    16     0     4  80.0 |
|     SFP/BUSD |      8 |          -2.88 |         -23.02 |           -34.571 |          -3.46 |  1 day, 16:38:00 |     6     0     2  75.0 |
|      IQ/BUSD |     21 |          -1.10 |         -23.13 |           -34.729 |          -3.47 |  1 day, 15:44:00 |    17     0     4  81.0 |
|   SUPER/BUSD |      6 |          -3.95 |         -23.72 |           -35.608 |          -3.56 |  1 day, 13:05:00 |     4     0     2  66.7 |
|     CVP/BUSD |     19 |          -1.26 |         -23.85 |           -35.808 |          -3.58 |  1 day, 17:20:00 |    15     0     4  78.9 |
|    COMP/BUSD |     20 |          -1.39 |         -27.82 |           -41.779 |          -4.18 |   1 day, 6:50:00 |    16     0     4  80.0 |
|     TLM/BUSD |      5 |          -5.58 |         -27.88 |           -41.869 |          -4.19 |         19:51:00 |     3     0     2  60.0 |
|     ONE/BUSD |     10 |          -2.81 |         -28.11 |           -42.205 |          -4.22 |         23:20:00 |     7     0     3  70.0 |
|     MDX/BUSD |      5 |          -5.94 |         -29.72 |           -44.632 |          -4.46 |  3 days, 3:27:00 |     3     0     2  60.0 |
|     GTC/BUSD |      4 |          -7.68 |         -30.70 |           -46.097 |          -4.61 | 2 days, 12:30:00 |     2     0     2  50.0 |
|    DASH/BUSD |     12 |          -2.70 |         -32.36 |           -48.588 |          -4.86 | 2 days, 15:44:00 |     9     0     3  75.0 |
|    AAVE/BUSD |     28 |          -1.20 |         -33.52 |           -50.335 |          -5.03 |   1 day, 3:57:00 |    22     0     6  78.6 |
|     GRT/BUSD |      9 |          -3.88 |         -34.96 |           -52.493 |          -5.25 |  2 days, 5:05:00 |     6     0     3  66.7 |
|     FIO/BUSD |     20 |          -1.87 |         -37.32 |           -56.029 |          -5.60 |         22:40:00 |    15     0     5  75.0 |
|     BCH/BUSD |     18 |          -2.09 |         -37.61 |           -56.475 |          -5.65 |  1 day, 23:43:00 |    14     0     4  77.8 |
|     FXS/BUSD |     22 |          -1.87 |         -41.11 |           -61.733 |          -6.17 |  1 day, 20:05:00 |    17     0     5  77.3 |
|     ENJ/BUSD |     14 |          -2.97 |         -41.51 |           -62.331 |          -6.23 |   1 day, 2:14:00 |    10     0     4  71.4 |
|     XVS/BUSD |     16 |          -3.05 |         -48.76 |           -73.215 |          -7.32 |         10:20:00 |    11     0     5  68.8 |
|     TVK/BUSD |      6 |          -8.55 |         -51.27 |           -76.986 |          -7.70 |  1 day, 21:02:00 |     3     0     3  50.0 |
|   FORTH/BUSD |     14 |          -4.30 |         -60.22 |           -90.414 |          -9.04 |  1 day, 20:05:00 |     9     0     5  64.3 |
|    DOGE/BUSD |     18 |          -4.08 |         -73.35 |          -110.136 |         -11.01 |  2 days, 7:22:00 |    12     0     6  66.7 |
|     EPS/BUSD |     12 |          -6.31 |         -75.72 |          -113.687 |         -11.37 |  1 day, 10:15:00 |     7     0     5  58.3 |
|        TOTAL |   1364 |           0.56 |         767.09 |          1151.790 |         115.18 |   1 day, 5:04:00 |  1163     0   201  85.3 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |    1163 |   1163     0     0   100 |           4.09 |        4759.58 |          7146.5   |         793.26 |
|          stop_loss |     195 |      0     0   195     0 |         -20.16 |       -3931.2  |         -5902.7   |        -655.2  |
|         force_sell |       6 |      0     0     6     0 |         -10.21 |         -61.28 |           -92.012 |         -10.21 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|  BAND/BUSD |      1 |          -5.58 |          -5.58 |            -8.374 |          -0.84 |         23:45:00 |     0     0     1     0 |
| FRONT/BUSD |      1 |          -7.50 |          -7.50 |           -11.262 |          -1.13 | 5 days, 21:15:00 |     0     0     1     0 |
| ALPHA/BUSD |      1 |          -9.52 |          -9.52 |           -14.289 |          -1.43 | 2 days, 23:30:00 |     0     0     1     0 |
|   BEL/BUSD |      1 |         -11.57 |         -11.57 |           -17.369 |          -1.74 |  4 days, 4:00:00 |     0     0     1     0 |
|   ANT/BUSD |      1 |         -13.31 |         -13.31 |           -19.985 |          -2.00 |  9 days, 9:00:00 |     0     0     1     0 |
|  ALGO/BUSD |      1 |         -13.81 |         -13.81 |           -20.734 |          -2.07 | 4 days, 13:45:00 |     0     0     1     0 |
|      TOTAL |      6 |         -10.21 |         -61.28 |           -92.012 |          -9.20 | 4 days, 15:52:00 |     0     0     6     0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-01-01 00:00:00 |
| Backtesting to         | 2021-10-12 15:45:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 1364 / 4.8          |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 2151.790 BUSD       |
| Absolute profit        | 1151.790 BUSD       |
| Total profit %         | 115.18%             |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 204600.000 BUSD     |
|                        |                     |
| Best Pair              | ALPHA/BUSD 96.65%   |
| Worst Pair             | EPS/BUSD -75.72%    |
| Best trade             | DATA/BUSD 55.16%    |
| Worst trade            | DEXE/BUSD -20.19%   |
| Best day               | 208.574 BUSD        |
| Worst day              | -259.436 BUSD       |
| Days win/draw/lose     | 195 / 22 / 68       |
| Avg. Duration Winners  | 22:58:00            |
| Avg. Duration Loser    | 2 days, 16:24:00    |
| Rejected Buy signals   | 2198999             |
|                        |                     |
| Min balance            | 1004.209 BUSD       |
| Max balance            | 2256.406 BUSD       |
| Drawdown               | 589.17%             |
| Drawdown               | 884.632 BUSD        |
| Drawdown high          | 1008.281 BUSD       |
| Drawdown low           | 123.649 BUSD        |
| Drawdown Start         | 2021-02-22 08:15:00 |
| Drawdown End           | 2021-06-22 13:45:00 |
| Market change          | 759.59%             |
================================================

2021-01-01 00:00:00 -> 2021-10-12 15:45:00 | Max open trades : 6
======================================================================== STRATEGY SUMMARY =======================================================================
|   Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |   Avg Duration |   Win  Draw  Loss  Win% |              Drawdown |
|------------+--------+----------------+----------------+-------------------+----------------+----------------+-------------------------+-----------------------|
|   Apollo11 |   1319 |           0.45 |         587.37 |           881.941 |          88.19 | 1 day, 6:03:00 |  1120     0   199  84.9 | 896.479 BUSD  597.06% |
| Apollo11_2 |   1364 |           0.56 |         767.09 |          1151.790 |         115.18 | 1 day, 5:04:00 |  1163     0   201  85.3 | 884.632 BUSD  589.17% |
=================================================================================================================================================================
```
# Setting ``CooldownPeriod`` to 0 minutes
```
Result for strategy Apollo11
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|   AERGO/BUSD |     45 |           2.22 |          99.95 |           150.076 |          15.01 |         20:27:00 |    41     0     4  91.1 |
|     AVA/BUSD |     20 |           3.69 |          73.87 |           110.913 |          11.09 |   1 day, 6:17:00 |    20     0     0   100 |
|     ANT/BUSD |     23 |           2.98 |          68.65 |           103.077 |          10.31 |   1 day, 6:30:00 |    22     0     1  95.7 |
|    DEXE/BUSD |     36 |           1.89 |          67.89 |           101.938 |          10.19 |   1 day, 7:59:00 |    31     0     5  86.1 |
|    HARD/BUSD |     16 |           3.99 |          63.78 |            95.762 |           9.58 |         12:05:00 |    16     0     0   100 |
|   CREAM/BUSD |     32 |           1.89 |          60.63 |            91.030 |           9.10 |  1 day, 23:39:00 |    28     0     4  87.5 |
|     AXS/BUSD |     21 |           2.78 |          58.42 |            87.710 |           8.77 |         11:46:00 |    19     0     2  90.5 |
|     DOT/BUSD |     15 |           3.74 |          56.16 |            84.321 |           8.43 |         15:32:00 |    15     0     0   100 |
|     PHA/BUSD |     11 |           5.08 |          55.86 |            83.875 |           8.39 |   1 day, 2:41:00 |    11     0     0   100 |
|     BEL/BUSD |     22 |           2.48 |          54.56 |            81.928 |           8.19 |         18:10:00 |    21     0     1  95.5 |
|   ALPHA/BUSD |     33 |           1.63 |          53.88 |            80.906 |           8.09 |         17:12:00 |    30     0     3  90.9 |
|     ATA/BUSD |     13 |           3.96 |          51.46 |            77.268 |           7.73 |  1 day, 10:27:00 |    12     0     1  92.3 |
|    RUNE/BUSD |     11 |           4.31 |          47.45 |            71.253 |           7.13 |         14:33:00 |    11     0     0   100 |
|     LIT/BUSD |     11 |           4.11 |          45.19 |            67.857 |           6.79 |         20:46:00 |    11     0     0   100 |
|     UFT/BUSD |     11 |           3.76 |          41.32 |            62.045 |           6.20 |         10:14:00 |    11     0     0   100 |
|     INJ/BUSD |     12 |           3.30 |          39.62 |            59.490 |           5.95 |         10:48:00 |    11     0     1  91.7 |
|     DGB/BUSD |     18 |           2.17 |          39.01 |            58.575 |           5.86 |   1 day, 0:00:00 |    17     0     1  94.4 |
|      AR/BUSD |     14 |           2.78 |          38.93 |            58.453 |           5.85 |         11:59:00 |    13     0     1  92.9 |
|    BAND/BUSD |     10 |           3.55 |          35.48 |            53.270 |           5.33 |  2 days, 7:36:00 |    10     0     0   100 |
|      IQ/BUSD |     18 |           1.93 |          34.80 |            52.246 |           5.22 |         13:55:00 |    17     0     1  94.4 |
|    LINA/BUSD |      7 |           4.49 |          31.45 |            47.224 |           4.72 |         11:26:00 |     7     0     0   100 |
|     TKO/BUSD |      5 |           6.23 |          31.15 |            46.774 |           4.68 |   1 day, 4:27:00 |     5     0     0   100 |
|    NEAR/BUSD |      9 |           3.40 |          30.57 |            45.905 |           4.59 |         18:22:00 |     9     0     0   100 |
|    DODO/BUSD |      9 |           3.33 |          29.94 |            44.950 |           4.49 |         12:28:00 |     9     0     0   100 |
|     LTC/BUSD |     10 |           2.99 |          29.86 |            44.841 |           4.48 |  2 days, 1:48:00 |    10     0     0   100 |
|    ALGO/BUSD |     31 |           0.95 |          29.49 |            44.283 |           4.43 |   1 day, 2:20:00 |    27     0     4  87.1 |
|    CTSI/BUSD |     12 |           2.21 |          26.51 |            39.805 |           3.98 |  2 days, 4:50:00 |    11     0     1  91.7 |
|   AUDIO/BUSD |     31 |           0.76 |          23.60 |            35.432 |           3.54 |  1 day, 11:50:00 |    27     0     4  87.1 |
|     WRX/BUSD |      3 |           7.55 |          22.64 |            33.994 |           3.40 |          2:10:00 |     3     0     0   100 |
|     CRV/BUSD |     24 |           0.83 |          19.91 |            29.897 |           2.99 |  1 day, 12:36:00 |    21     0     3  87.5 |
|     XRP/BUSD |      5 |           3.55 |          17.74 |            26.636 |           2.66 |   1 day, 4:03:00 |     5     0     0   100 |
|    SAND/BUSD |      9 |           1.94 |          17.46 |            26.209 |           2.62 |   1 day, 1:13:00 |     8     0     1  88.9 |
|     SFP/BUSD |      6 |           2.88 |          17.30 |            25.969 |           2.60 |          3:40:00 |     6     0     0   100 |
|    PROM/BUSD |     24 |           0.71 |          17.13 |            25.725 |           2.57 |  1 day, 18:24:00 |    21     0     3  87.5 |
|    ATOM/BUSD |     20 |           0.84 |          16.71 |            25.094 |           2.51 |         21:41:00 |    17     0     3  85.0 |
|    LUNA/BUSD |     18 |           0.81 |          14.62 |            21.959 |           2.20 |  1 day, 21:08:00 |    15     0     3  83.3 |
|    LINK/BUSD |      5 |           2.84 |          14.22 |            21.346 |           2.13 |   1 day, 2:39:00 |     5     0     0   100 |
|    PERP/BUSD |     10 |           1.30 |          12.96 |            19.453 |           1.95 |         11:10:00 |     9     0     1  90.0 |
|     ONE/BUSD |     12 |           1.04 |          12.49 |            18.761 |           1.88 |         16:20:00 |    10     0     2  83.3 |
|    STMX/BUSD |      3 |           3.82 |          11.45 |            17.191 |           1.72 |         14:55:00 |     3     0     0   100 |
|     FTM/BUSD |      3 |           3.66 |          10.98 |            16.488 |           1.65 |  1 day, 14:20:00 |     3     0     0   100 |
|   WAVES/BUSD |      4 |           2.73 |          10.92 |            16.403 |           1.64 |          9:34:00 |     4     0     0   100 |
|     TWT/BUSD |      3 |           3.38 |          10.13 |            15.216 |           1.52 |         12:55:00 |     3     0     0   100 |
|    KEEP/BUSD |      3 |           3.37 |          10.11 |            15.175 |           1.52 |  3 days, 2:25:00 |     3     0     0   100 |
|    AAVE/BUSD |     27 |           0.33 |           8.86 |            13.303 |           1.33 |  1 day, 13:13:00 |    23     0     4  85.2 |
| AUCTION/BUSD |     16 |           0.49 |           7.80 |            11.708 |           1.17 |         18:22:00 |    14     0     2  87.5 |
|    BZRX/BUSD |     16 |           0.43 |           6.95 |            10.433 |           1.04 |         10:27:00 |    13     0     3  81.2 |
|     ZEC/BUSD |      2 |           3.12 |           6.23 |             9.360 |           0.94 |          2:38:00 |     2     0     0   100 |
|   SUSHI/BUSD |      7 |           0.84 |           5.86 |             8.805 |           0.88 |   1 day, 2:39:00 |     6     0     1  85.7 |
|    SHIB/BUSD |      1 |           5.83 |           5.83 |             8.750 |           0.88 |  1 day, 12:30:00 |     1     0     0   100 |
|    REEF/BUSD |      7 |           0.67 |           4.67 |             7.013 |           0.70 |         16:24:00 |     6     0     1  85.7 |
|   SUPER/BUSD |      8 |           0.54 |           4.33 |             6.505 |           0.65 |   1 day, 6:00:00 |     7     0     1  87.5 |
|     XVG/BUSD |      1 |           3.92 |           3.92 |             5.890 |           0.59 |          0:30:00 |     1     0     0   100 |
|     BTT/BUSD |      8 |           0.46 |           3.70 |             5.562 |           0.56 |         22:15:00 |     7     0     1  87.5 |
|    IOST/BUSD |      7 |           0.41 |           2.84 |             4.257 |           0.43 |          5:09:00 |     6     0     1  85.7 |
|     SKL/BUSD |      7 |           0.24 |           1.68 |             2.521 |           0.25 |         20:30:00 |     6     0     1  85.7 |
|     FIL/BUSD |     18 |           0.09 |           1.63 |             2.452 |           0.25 |   1 day, 9:01:00 |    15     0     3  83.3 |
|     FIO/BUSD |     18 |           0.06 |           1.13 |             1.695 |           0.17 |   1 day, 8:47:00 |    15     0     3  83.3 |
|     KNC/BUSD |      8 |           0.12 |           0.92 |             1.389 |           0.14 |   1 day, 1:04:00 |     7     0     1  87.5 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    POND/BUSD |      8 |          -0.12 |          -0.95 |            -1.429 |          -0.14 |         18:02:00 |     7     0     1  87.5 |
|    BAKE/BUSD |     18 |          -0.08 |          -1.46 |            -2.195 |          -0.22 |  1 day, 10:29:00 |    15     0     3  83.3 |
|     CTK/BUSD |     11 |          -0.13 |          -1.47 |            -2.203 |          -0.22 |  1 day, 17:25:00 |     9     0     2  81.8 |
|     SXP/BUSD |      7 |          -0.31 |          -2.18 |            -3.279 |          -0.33 |         15:04:00 |     6     0     1  85.7 |
|    NANO/BUSD |      9 |          -0.28 |          -2.52 |            -3.787 |          -0.38 |  1 day, 23:05:00 |     7     0     2  77.8 |
|   OCEAN/BUSD |      7 |          -0.38 |          -2.69 |            -4.042 |          -0.40 |         16:02:00 |     6     0     1  85.7 |
|   1INCH/BUSD |     14 |          -0.21 |          -2.92 |            -4.386 |          -0.44 |         19:14:00 |    12     0     2  85.7 |
|   FRONT/BUSD |     22 |          -0.20 |          -4.50 |            -6.754 |          -0.68 |   1 day, 4:01:00 |    17     0     5  77.3 |
|    AVAX/BUSD |     19 |          -0.24 |          -4.56 |            -6.847 |          -0.68 |         20:24:00 |    16     0     3  84.2 |
|    POLS/BUSD |      5 |          -0.92 |          -4.60 |            -6.910 |          -0.69 |   1 day, 5:06:00 |     4     0     1  80.0 |
|     XTZ/BUSD |      6 |          -0.81 |          -4.84 |            -7.267 |          -0.73 |  1 day, 13:08:00 |     5     0     1  83.3 |
|    DOCK/BUSD |      5 |          -1.25 |          -6.27 |            -9.415 |          -0.94 |   1 day, 7:30:00 |     4     0     1  80.0 |
|    DASH/BUSD |     13 |          -0.53 |          -6.90 |           -10.360 |          -1.04 |   1 day, 0:17:00 |    11     0     2  84.6 |
|     GTC/BUSD |      4 |          -1.74 |          -6.97 |           -10.464 |          -1.05 |  2 days, 5:00:00 |     3     0     1  75.0 |
|     SRM/BUSD |      5 |          -1.47 |          -7.35 |           -11.040 |          -1.10 |  1 day, 15:12:00 |     4     0     1  80.0 |
|     RSR/BUSD |      9 |          -0.87 |          -7.81 |           -11.726 |          -1.17 |   1 day, 2:02:00 |     7     0     2  77.8 |
|    IDEX/BUSD |      9 |          -0.88 |          -7.93 |           -11.906 |          -1.19 |  2 days, 5:17:00 |     7     0     2  77.8 |
|     ZIL/BUSD |      4 |          -2.02 |          -8.08 |           -12.134 |          -1.21 |         10:41:00 |     3     0     1  75.0 |
|    IOTX/BUSD |      4 |          -2.04 |          -8.15 |           -12.240 |          -1.22 |         20:00:00 |     3     0     1  75.0 |
|    EGLD/BUSD |     18 |          -0.45 |          -8.16 |           -12.250 |          -1.23 |   1 day, 9:04:00 |    15     0     3  83.3 |
|     MIR/BUSD |     12 |          -0.69 |          -8.25 |           -12.386 |          -1.24 | 2 days, 19:54:00 |     9     0     3  75.0 |
|     KSM/BUSD |     13 |          -0.71 |          -9.20 |           -13.811 |          -1.38 |         14:58:00 |    11     0     2  84.6 |
|     YFI/BUSD |      4 |          -2.40 |          -9.59 |           -14.400 |          -1.44 |  1 day, 21:08:00 |     3     0     1  75.0 |
|     TVK/BUSD |      4 |          -2.44 |          -9.76 |           -14.659 |          -1.47 |   1 day, 2:19:00 |     3     0     1  75.0 |
|     SOL/BUSD |      4 |          -2.56 |         -10.25 |           -15.392 |          -1.54 | 2 days, 16:30:00 |     3     0     1  75.0 |
|    COTI/BUSD |      3 |          -3.66 |         -10.99 |           -16.500 |          -1.65 |   1 day, 8:45:00 |     2     0     1  66.7 |
|    MANA/BUSD |     10 |          -1.25 |         -12.55 |           -18.840 |          -1.88 |  1 day, 23:22:00 |     8     0     2  80.0 |
|     SNX/BUSD |      3 |          -4.93 |         -14.79 |           -22.211 |          -2.22 |   1 day, 7:55:00 |     2     0     1  66.7 |
|     ICP/BUSD |      8 |          -1.90 |         -15.22 |           -22.860 |          -2.29 |   1 day, 1:09:00 |     6     0     2  75.0 |
|     GRT/BUSD |      7 |          -2.19 |         -15.31 |           -22.986 |          -2.30 |  2 days, 7:06:00 |     5     0     2  71.4 |
|     CVP/BUSD |     18 |          -0.95 |         -17.15 |           -25.752 |          -2.58 |  1 day, 21:50:00 |    14     0     4  77.8 |
|     UNI/BUSD |      8 |          -2.92 |         -23.32 |           -35.018 |          -3.50 |  2 days, 4:06:00 |     6     0     2  75.0 |
|     HOT/BUSD |      6 |          -4.46 |         -26.77 |           -40.188 |          -4.02 |  1 day, 10:32:00 |     4     0     2  66.7 |
|     MKR/BUSD |     12 |          -2.23 |         -26.81 |           -40.250 |          -4.02 | 3 days, 16:39:00 |     9     0     3  75.0 |
|     BCH/BUSD |     20 |          -1.37 |         -27.39 |           -41.126 |          -4.11 |  1 day, 13:40:00 |    16     0     4  80.0 |
|     EPS/BUSD |     11 |          -2.76 |         -30.36 |           -45.584 |          -4.56 |         21:00:00 |     8     0     3  72.7 |
|     MDX/BUSD |      5 |          -6.33 |         -31.67 |           -47.557 |          -4.76 |  4 days, 6:12:00 |     3     0     2  60.0 |
|   MATIC/BUSD |      9 |          -3.72 |         -33.52 |           -50.329 |          -5.03 |         22:38:00 |     6     0     3  66.7 |
|   FORTH/BUSD |      9 |          -3.74 |         -33.70 |           -50.596 |          -5.06 |   1 day, 8:17:00 |     6     0     3  66.7 |
|     ENJ/BUSD |     16 |          -2.16 |         -34.56 |           -51.892 |          -5.19 |         19:50:00 |    12     0     4  75.0 |
|    DEGO/BUSD |     10 |          -3.88 |         -38.80 |           -58.260 |          -5.83 |  1 day, 22:56:00 |     7     0     3  70.0 |
|    DATA/BUSD |     17 |          -2.53 |         -43.05 |           -64.636 |          -6.46 |  1 day, 21:24:00 |    10     0     7  58.8 |
|   ALICE/BUSD |     16 |          -2.76 |         -44.18 |           -66.337 |          -6.63 |   1 day, 5:34:00 |    12     0     4  75.0 |
|     TLM/BUSD |      7 |          -6.56 |         -45.95 |           -69.000 |          -6.90 |         15:54:00 |     4     0     3  57.1 |
|    COMP/BUSD |     23 |          -2.87 |         -66.02 |           -99.131 |          -9.91 |  1 day, 14:31:00 |    17     0     6  73.9 |
|     XVS/BUSD |     17 |          -4.26 |         -72.47 |          -108.815 |         -10.88 |         12:53:00 |    11     0     6  64.7 |
|    DOGE/BUSD |     22 |          -3.63 |         -79.77 |          -119.776 |         -11.98 |  1 day, 23:35:00 |    15     0     7  68.2 |
|     FXS/BUSD |     22 |          -5.08 |        -111.83 |          -167.914 |         -16.79 |  2 days, 8:45:00 |    14     0     8  63.6 |
|        TOTAL |   1322 |           0.47 |         619.07 |           929.529 |          92.95 |   1 day, 6:05:00 |  1124     0   198  85.0 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |    1124 |   1124     0     0   100 |           4.04 |        4536.77 |           6811.96 |         756.13 |
|          stop_loss |     192 |      0     0   192     0 |         -20.16 |       -3871.04 |          -5812.37 |        -645.17 |
|         force_sell |       6 |      0     0     6     0 |          -7.78 |         -46.66 |            -70.06 |          -7.78 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|  ATOM/BUSD |      1 |          -3.78 |          -3.78 |            -5.674 |          -0.57 |  3 days, 0:00:00 |     0     0     1     0 |
| CREAM/BUSD |      1 |          -5.36 |          -5.36 |            -8.042 |          -0.80 |  9 days, 9:00:00 |     0     0     1     0 |
| FRONT/BUSD |      1 |          -7.50 |          -7.50 |           -11.262 |          -1.13 | 5 days, 21:15:00 |     0     0     1     0 |
|  ALGO/BUSD |      1 |          -8.94 |          -8.94 |           -13.425 |          -1.34 |  2 days, 4:00:00 |     0     0     1     0 |
| ALPHA/BUSD |      1 |          -9.52 |          -9.52 |           -14.289 |          -1.43 | 2 days, 23:30:00 |     0     0     1     0 |
|   BEL/BUSD |      1 |         -11.57 |         -11.57 |           -17.369 |          -1.74 |  4 days, 4:00:00 |     0     0     1     0 |
|      TOTAL |      6 |          -7.78 |         -46.66 |           -70.060 |          -7.01 | 4 days, 14:18:00 |     0     0     6     0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-01-01 00:00:00 |
| Backtesting to         | 2021-10-12 16:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 1322 / 4.65         |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1929.529 BUSD       |
| Absolute profit        | 929.529 BUSD        |
| Total profit %         | 92.95%              |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 198300.000 BUSD     |
|                        |                     |
| Best Pair              | AERGO/BUSD 99.95%   |
| Worst Pair             | FXS/BUSD -111.83%   |
| Best trade             | DATA/BUSD 55.16%    |
| Worst trade            | CVP/BUSD -20.48%    |
| Best day               | 185.423 BUSD        |
| Worst day              | -258.466 BUSD       |
| Days win/draw/lose     | 185 / 30 / 70       |
| Avg. Duration Winners  | 22:55:00            |
| Avg. Duration Loser    | 2 days, 22:51:00    |
| Rejected Buy signals   | 2204350             |
|                        |                     |
| Min balance            | 1004.209 BUSD       |
| Max balance            | 2108.161 BUSD       |
| Drawdown               | 597.06%             |
| Drawdown               | 896.479 BUSD        |
| Drawdown high          | 1108.161 BUSD       |
| Drawdown low           | 211.682 BUSD        |
| Drawdown Start         | 2021-02-20 13:45:00 |
| Drawdown End           | 2021-06-22 14:00:00 |
| Market change          | 757.74%             |
================================================

Result for strategy Apollo11_2
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|   AERGO/BUSD |     47 |           2.03 |          95.45 |           143.316 |          14.33 |         17:49:00 |    43     0     4  91.5 |
|   ALPHA/BUSD |     36 |           2.59 |          93.33 |           140.142 |          14.01 |         15:05:00 |    34     0     2  94.4 |
|    DEXE/BUSD |     45 |           2.01 |          90.63 |           136.079 |          13.61 |   1 day, 6:42:00 |    39     0     6  86.7 |
|     AVA/BUSD |     22 |           3.62 |          79.73 |           119.715 |          11.97 |         21:16:00 |    22     0     0   100 |
|    HARD/BUSD |     19 |           3.63 |          68.99 |           103.584 |          10.36 |         10:57:00 |    19     0     0   100 |
| AUCTION/BUSD |     24 |           2.65 |          63.68 |            95.618 |           9.56 |         21:13:00 |    23     0     1  95.8 |
|   CREAM/BUSD |     34 |           1.86 |          63.31 |            95.066 |           9.51 |   1 day, 3:22:00 |    30     0     4  88.2 |
|     ANT/BUSD |     23 |           2.74 |          63.02 |            94.631 |           9.46 |  1 day, 16:27:00 |    21     0     2  91.3 |
|      AR/BUSD |     14 |           4.31 |          60.34 |            90.595 |           9.06 |          8:20:00 |    14     0     0   100 |
|     BEL/BUSD |     23 |           2.58 |          59.41 |            89.203 |           8.92 |         17:29:00 |    22     0     1  95.7 |
|     ATA/BUSD |     13 |           4.44 |          57.75 |            86.709 |           8.67 |         23:13:00 |    12     0     1  92.3 |
|     LTC/BUSD |     11 |           4.87 |          53.59 |            80.473 |           8.05 |  1 day, 21:29:00 |    11     0     0   100 |
|    LUNA/BUSD |     16 |           3.10 |          49.63 |            74.522 |           7.45 |  1 day, 20:08:00 |    14     0     2  87.5 |
|     PHA/BUSD |     13 |           3.45 |          44.88 |            67.383 |           6.74 |         21:44:00 |    12     0     1  92.3 |
|     AXS/BUSD |     18 |           2.28 |          41.13 |            61.751 |           6.18 |          9:11:00 |    16     0     2  88.9 |
|    COTI/BUSD |      4 |           9.16 |          36.65 |            55.033 |           5.50 |   1 day, 2:38:00 |     3     0     1  75.0 |
|    LINA/BUSD |      8 |           4.24 |          33.96 |            50.985 |           5.10 |         11:22:00 |     8     0     0   100 |
|     WRX/BUSD |      5 |           6.18 |          30.91 |            46.406 |           4.64 |         19:48:00 |     5     0     0   100 |
|     LIT/BUSD |      7 |           4.34 |          30.35 |            45.576 |           4.56 |          8:34:00 |     7     0     0   100 |
|     BTT/BUSD |      8 |           3.59 |          28.69 |            43.075 |           4.31 |          9:00:00 |     8     0     0   100 |
|     DOT/BUSD |     14 |           2.05 |          28.64 |            43.003 |           4.30 |         10:12:00 |    13     0     1  92.9 |
|    BAND/BUSD |      9 |           3.10 |          27.87 |            41.845 |           4.18 |  1 day, 11:23:00 |     8     0     1  88.9 |
|   SUSHI/BUSD |      8 |           3.45 |          27.62 |            41.476 |           4.15 |         13:19:00 |     8     0     0   100 |
|     INJ/BUSD |     10 |           2.60 |          25.99 |            39.022 |           3.90 |         10:33:00 |     9     0     1  90.0 |
|    AVAX/BUSD |     22 |           1.16 |          25.58 |            38.410 |           3.84 |         15:03:00 |    20     0     2  90.9 |
|    NEAR/BUSD |      7 |           3.45 |          24.18 |            36.314 |           3.63 |         22:56:00 |     7     0     0   100 |
|   AUDIO/BUSD |     32 |           0.75 |          24.00 |            36.034 |           3.60 |  1 day, 17:22:00 |    28     0     4  87.5 |
|    SAND/BUSD |     11 |           2.01 |          22.16 |            33.275 |           3.33 |         21:44:00 |    10     0     1  90.9 |
|    IDEX/BUSD |     10 |           2.21 |          22.09 |            33.167 |           3.32 |  1 day, 18:28:00 |     9     0     1  90.0 |
|    NANO/BUSD |      7 |           3.06 |          21.42 |            32.163 |           3.22 |  1 day, 10:32:00 |     6     0     1  85.7 |
|     XRP/BUSD |      6 |           3.55 |          21.32 |            32.012 |           3.20 |  4 days, 2:12:00 |     6     0     0   100 |
|    IOST/BUSD |      5 |           4.22 |          21.11 |            31.692 |           3.17 |          2:45:00 |     5     0     0   100 |
|    DODO/BUSD |      5 |           4.00 |          20.01 |            30.052 |           3.01 |  1 day, 16:21:00 |     5     0     0   100 |
|    CTSI/BUSD |     13 |           1.53 |          19.88 |            29.845 |           2.98 |         16:27:00 |    12     0     1  92.3 |
|    RUNE/BUSD |     10 |           1.99 |          19.87 |            29.839 |           2.98 |   1 day, 2:22:00 |     9     0     1  90.0 |
|    LINK/BUSD |      5 |           3.81 |          19.03 |            28.573 |           2.86 |         18:21:00 |     5     0     0   100 |
|    PERP/BUSD |      9 |           2.05 |          18.43 |            27.673 |           2.77 |         16:05:00 |     8     0     1  88.9 |
|     UFT/BUSD |      9 |           2.03 |          18.24 |            27.393 |           2.74 |         18:07:00 |     8     0     1  88.9 |
|     FIL/BUSD |     21 |           0.86 |          18.16 |            27.269 |           2.73 |  1 day, 22:41:00 |    18     0     3  85.7 |
|   1INCH/BUSD |     18 |           0.99 |          17.76 |            26.664 |           2.67 |          9:02:00 |    16     0     2  88.9 |
|     TKO/BUSD |      5 |           3.55 |          17.75 |            26.651 |           2.67 |   1 day, 4:30:00 |     5     0     0   100 |
|    ATOM/BUSD |     19 |           0.77 |          14.64 |            21.982 |           2.20 |         22:17:00 |    17     0     2  89.5 |
|    POND/BUSD |      5 |           2.87 |          14.34 |            21.527 |           2.15 |   1 day, 0:15:00 |     5     0     0   100 |
|     FTM/BUSD |      4 |           3.34 |          13.36 |            20.063 |           2.01 |   1 day, 5:26:00 |     4     0     0   100 |
|    DATA/BUSD |     21 |           0.60 |          12.65 |            18.997 |           1.90 |  1 day, 11:08:00 |    16     0     5  76.2 |
|   WAVES/BUSD |      4 |           3.07 |          12.27 |            18.425 |           1.84 |          9:49:00 |     4     0     0   100 |
|     RSR/BUSD |      8 |           1.50 |          12.03 |            18.063 |           1.81 |         14:49:00 |     7     0     1  87.5 |
|    ALGO/BUSD |     37 |           0.30 |          10.95 |            16.441 |           1.64 |         23:24:00 |    32     0     5  86.5 |
|     MIR/BUSD |     11 |           0.93 |          10.21 |            15.335 |           1.53 |  3 days, 3:59:00 |     9     0     2  81.8 |
|     ZEC/BUSD |      3 |           3.01 |           9.03 |            13.559 |           1.36 |         11:30:00 |     3     0     0   100 |
|     MKR/BUSD |     11 |           0.56 |           6.13 |             9.210 |           0.92 | 3 days, 13:19:00 |     9     0     2  81.8 |
|     ICP/BUSD |      8 |           0.69 |           5.54 |             8.321 |           0.83 |         13:49:00 |     7     0     1  87.5 |
|     KSM/BUSD |     18 |           0.24 |           4.28 |             6.426 |           0.64 |         11:36:00 |    16     0     2  88.9 |
|    STMX/BUSD |      2 |           2.11 |           4.22 |             6.341 |           0.63 | 4 days, 17:45:00 |     2     0     0   100 |
|    REEF/BUSD |      6 |           0.68 |           4.08 |             6.125 |           0.61 |   1 day, 3:32:00 |     5     0     1  83.3 |
|     XVG/BUSD |      1 |           3.92 |           3.92 |             5.890 |           0.59 |          0:30:00 |     1     0     0   100 |
|    IOTX/BUSD |      7 |           0.50 |           3.52 |             5.282 |           0.53 |   1 day, 7:39:00 |     6     0     1  85.7 |
|    SHIB/BUSD |      1 |           2.43 |           2.43 |             3.648 |           0.36 |          3:15:00 |     1     0     0   100 |
|   MATIC/BUSD |      7 |           0.32 |           2.21 |             3.321 |           0.33 |         11:11:00 |     6     0     1  85.7 |
|    PROM/BUSD |     22 |           0.10 |           2.11 |             3.166 |           0.32 |  1 day, 16:44:00 |    19     0     3  86.4 |
|     KNC/BUSD |      8 |           0.25 |           2.03 |             3.041 |           0.30 |   1 day, 1:00:00 |     7     0     1  87.5 |
|   OCEAN/BUSD |      8 |           0.18 |           1.47 |             2.210 |           0.22 |         16:58:00 |     7     0     1  87.5 |
|    BZRX/BUSD |     14 |           0.10 |           1.45 |             2.173 |           0.22 |          5:42:00 |    12     0     2  85.7 |
|     DGB/BUSD |     17 |           0.07 |           1.24 |             1.856 |           0.19 |  1 day, 18:45:00 |    15     0     2  88.2 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     UNI/BUSD |      5 |          -0.04 |          -0.18 |            -0.271 |          -0.03 |   1 day, 9:42:00 |     3     0     2  60.0 |
|     SXP/BUSD |      8 |          -0.06 |          -0.44 |            -0.666 |          -0.07 |          9:52:00 |     7     0     1  87.5 |
|     TWT/BUSD |      6 |          -0.15 |          -0.92 |            -1.376 |          -0.14 |          8:05:00 |     5     0     1  83.3 |
|    EGLD/BUSD |     19 |          -0.08 |          -1.48 |            -2.227 |          -0.22 |   1 day, 4:25:00 |    16     0     3  84.2 |
|     ZIL/BUSD |      6 |          -0.29 |          -1.76 |            -2.646 |          -0.26 |          9:00:00 |     5     0     1  83.3 |
|     SOL/BUSD |      7 |          -0.32 |          -2.22 |            -3.328 |          -0.33 |   1 day, 8:49:00 |     6     0     1  85.7 |
|      IQ/BUSD |     20 |          -0.15 |          -2.97 |            -4.459 |          -0.45 |  1 day, 11:02:00 |    17     0     3  85.0 |
|     SRM/BUSD |      6 |          -0.53 |          -3.21 |            -4.817 |          -0.48 |  1 day, 14:28:00 |     5     0     1  83.3 |
|    POLS/BUSD |      5 |          -0.92 |          -4.60 |            -6.910 |          -0.69 |   1 day, 5:06:00 |     4     0     1  80.0 |
|    KEEP/BUSD |      4 |          -1.30 |          -5.19 |            -7.786 |          -0.78 | 2 days, 23:56:00 |     3     0     1  75.0 |
|    DEGO/BUSD |     12 |          -0.44 |          -5.31 |            -7.973 |          -0.80 |  2 days, 0:32:00 |    10     0     2  83.3 |
|     SNX/BUSD |      6 |          -0.91 |          -5.43 |            -8.158 |          -0.82 |         19:35:00 |     5     0     1  83.3 |
|     SKL/BUSD |      9 |          -0.68 |          -6.12 |            -9.197 |          -0.92 |   1 day, 0:08:00 |     7     0     2  77.8 |
|    BAKE/BUSD |     16 |          -0.45 |          -7.25 |           -10.879 |          -1.09 |   1 day, 1:38:00 |    13     0     3  81.2 |
|     XTZ/BUSD |      5 |          -1.63 |          -8.15 |           -12.240 |          -1.22 |         18:06:00 |     4     0     1  80.0 |
|    DOCK/BUSD |      4 |          -2.10 |          -8.40 |           -12.609 |          -1.26 |  1 day, 12:56:00 |     3     0     1  75.0 |
|    MANA/BUSD |     11 |          -0.84 |          -9.22 |           -13.849 |          -1.38 |  1 day, 19:46:00 |     9     0     2  81.8 |
|   FRONT/BUSD |     20 |          -0.46 |          -9.28 |           -13.933 |          -1.39 |   1 day, 4:52:00 |    15     0     5  75.0 |
|     YFI/BUSD |      4 |          -2.42 |          -9.67 |           -14.523 |          -1.45 |  5 days, 3:34:00 |     3     0     1  75.0 |
|     CTK/BUSD |     14 |          -1.05 |         -14.77 |           -22.175 |          -2.22 |   1 day, 9:08:00 |    11     0     3  78.6 |
|     HOT/BUSD |     10 |          -1.63 |         -16.32 |           -24.510 |          -2.45 |         15:00:00 |     8     0     2  80.0 |
|   ALICE/BUSD |     17 |          -0.99 |         -16.83 |           -25.275 |          -2.53 |         20:34:00 |    14     0     3  82.4 |
|     CRV/BUSD |     20 |          -0.87 |         -17.46 |           -26.211 |          -2.62 |  1 day, 16:10:00 |    16     0     4  80.0 |
|     SFP/BUSD |      8 |          -2.88 |         -23.02 |           -34.571 |          -3.46 |  1 day, 16:38:00 |     6     0     2  75.0 |
|   SUPER/BUSD |      6 |          -3.95 |         -23.72 |           -35.608 |          -3.56 |  1 day, 13:05:00 |     4     0     2  66.7 |
|     CVP/BUSD |     19 |          -1.26 |         -23.85 |           -35.808 |          -3.58 |  1 day, 17:20:00 |    15     0     4  78.9 |
|     TLM/BUSD |      5 |          -5.58 |         -27.88 |           -41.869 |          -4.19 |         19:51:00 |     3     0     2  60.0 |
|     MDX/BUSD |      5 |          -5.94 |         -29.72 |           -44.632 |          -4.46 |  3 days, 3:27:00 |     3     0     2  60.0 |
|    DASH/BUSD |     13 |          -2.30 |         -29.84 |           -44.798 |          -4.48 | 2 days, 11:38:00 |    10     0     3  76.9 |
|    COMP/BUSD |     19 |          -1.60 |         -30.37 |           -45.607 |          -4.56 |   1 day, 8:21:00 |    15     0     4  78.9 |
|     GTC/BUSD |      4 |          -7.68 |         -30.70 |           -46.097 |          -4.61 | 2 days, 12:30:00 |     2     0     2  50.0 |
|     ONE/BUSD |      9 |          -3.45 |         -31.04 |           -46.601 |          -4.66 |   1 day, 1:48:00 |     6     0     3  66.7 |
|     BCH/BUSD |     20 |          -1.62 |         -32.49 |           -48.789 |          -4.88 |  1 day, 19:52:00 |    16     0     4  80.0 |
|    AAVE/BUSD |     28 |          -1.20 |         -33.52 |           -50.335 |          -5.03 |   1 day, 3:57:00 |    22     0     6  78.6 |
|     GRT/BUSD |      9 |          -3.88 |         -34.96 |           -52.493 |          -5.25 |  2 days, 5:05:00 |     6     0     3  66.7 |
|     FIO/BUSD |     20 |          -1.87 |         -37.32 |           -56.029 |          -5.60 |         22:40:00 |    15     0     5  75.0 |
|     FXS/BUSD |     22 |          -1.87 |         -41.11 |           -61.733 |          -6.17 |  1 day, 20:05:00 |    17     0     5  77.3 |
|     ENJ/BUSD |     14 |          -2.97 |         -41.51 |           -62.331 |          -6.23 |   1 day, 2:14:00 |    10     0     4  71.4 |
|     XVS/BUSD |     16 |          -3.05 |         -48.76 |           -73.215 |          -7.32 |         10:20:00 |    11     0     5  68.8 |
|     TVK/BUSD |      6 |          -8.55 |         -51.27 |           -76.986 |          -7.70 |  1 day, 21:02:00 |     3     0     3  50.0 |
|   FORTH/BUSD |     14 |          -4.30 |         -60.22 |           -90.414 |          -9.04 |  1 day, 20:05:00 |     9     0     5  64.3 |
|    DOGE/BUSD |     18 |          -4.08 |         -73.35 |          -110.136 |         -11.01 |  2 days, 7:22:00 |    12     0     6  66.7 |
|     EPS/BUSD |     12 |          -6.31 |         -75.72 |          -113.687 |         -11.37 |  1 day, 10:15:00 |     7     0     5  58.3 |
|        TOTAL |   1369 |           0.60 |         823.10 |          1235.881 |         123.59 |   1 day, 5:04:00 |  1169     0   200  85.4 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |    1169 |   1169     0     0   100 |           4.1  |        4795.42 |          7200.32  |         799.24 |
|          stop_loss |     194 |      0     0   194     0 |         -20.16 |       -3911.04 |         -5872.43  |        -651.84 |
|         force_sell |       6 |      0     0     6     0 |         -10.21 |         -61.28 |           -92.012 |         -10.21 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|  BAND/BUSD |      1 |          -5.58 |          -5.58 |            -8.374 |          -0.84 |         23:45:00 |     0     0     1     0 |
| FRONT/BUSD |      1 |          -7.50 |          -7.50 |           -11.262 |          -1.13 | 5 days, 21:15:00 |     0     0     1     0 |
| ALPHA/BUSD |      1 |          -9.52 |          -9.52 |           -14.289 |          -1.43 | 2 days, 23:30:00 |     0     0     1     0 |
|   BEL/BUSD |      1 |         -11.57 |         -11.57 |           -17.369 |          -1.74 |  4 days, 4:00:00 |     0     0     1     0 |
|   ANT/BUSD |      1 |         -13.31 |         -13.31 |           -19.985 |          -2.00 |  9 days, 9:00:00 |     0     0     1     0 |
|  ALGO/BUSD |      1 |         -13.81 |         -13.81 |           -20.734 |          -2.07 | 4 days, 13:45:00 |     0     0     1     0 |
|      TOTAL |      6 |         -10.21 |         -61.28 |           -92.012 |          -9.20 | 4 days, 15:52:00 |     0     0     6     0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-01-01 00:00:00 |
| Backtesting to         | 2021-10-12 16:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 1369 / 4.82         |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 2235.881 BUSD       |
| Absolute profit        | 1235.881 BUSD       |
| Total profit %         | 123.59%             |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 205350.000 BUSD     |
|                        |                     |
| Best Pair              | AERGO/BUSD 95.45%   |
| Worst Pair             | EPS/BUSD -75.72%    |
| Best trade             | DATA/BUSD 55.16%    |
| Worst trade            | DEXE/BUSD -20.19%   |
| Best day               | 208.574 BUSD        |
| Worst day              | -259.436 BUSD       |
| Days win/draw/lose     | 196 / 22 / 67       |
| Avg. Duration Winners  | 23:03:00            |
| Avg. Duration Loser    | 2 days, 16:12:00    |
| Rejected Buy signals   | 2200052             |
|                        |                     |
| Min balance            | 1004.209 BUSD       |
| Max balance            | 2340.496 BUSD       |
| Drawdown               | 589.17%             |
| Drawdown               | 884.632 BUSD        |
| Drawdown high          | 1092.372 BUSD       |
| Drawdown low           | 207.740 BUSD        |
| Drawdown Start         | 2021-02-22 08:15:00 |
| Drawdown End           | 2021-06-22 13:45:00 |
| Market change          | 757.74%             |
================================================

2021-01-01 00:00:00 -> 2021-10-12 16:00:00 | Max open trades : 6
======================================================================== STRATEGY SUMMARY =======================================================================
|   Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |   Avg Duration |   Win  Draw  Loss  Win% |              Drawdown |
|------------+--------+----------------+----------------+-------------------+----------------+----------------+-------------------------+-----------------------|
|   Apollo11 |   1322 |           0.47 |         619.07 |           929.529 |          92.95 | 1 day, 6:05:00 |  1124     0   198  85.0 | 896.479 BUSD  597.06% |
| Apollo11_2 |   1369 |           0.60 |         823.10 |          1235.881 |         123.59 | 1 day, 5:04:00 |  1169     0   200  85.4 | 884.632 BUSD  589.17% |
=================================================================================================================================================================
```