### PR TITLE
[WIP] Add additional TSL steps based on the lower profit recorded since buy

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 #ignore =
 max-line-length = 120
-max-complexity = 12
+max-complexity = 25
 exclude =
     .git,
     __pycache__,


### PR DESCRIPTION
# Year until today
```
Result for strategy Apollo11
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|   AERGO/BUSD |     43 |           2.25 |          96.91 |           145.507 |          14.55 |         21:03:00 |    40     0     3  93.0 |
|     AVA/BUSD |     20 |           3.69 |          73.87 |           110.913 |          11.09 |   1 day, 6:17:00 |    20     0     0   100 |
|    DEXE/BUSD |     36 |           1.89 |          67.89 |           101.938 |          10.19 |   1 day, 7:59:00 |    31     0     5  86.1 |
|    HARD/BUSD |     16 |           3.99 |          63.78 |            95.762 |           9.58 |         12:05:00 |    16     0     0   100 |
|     AXS/BUSD |     22 |           2.79 |          61.45 |            92.270 |           9.23 |         11:47:00 |    20     0     2  90.9 |
|   CREAM/BUSD |     32 |           1.89 |          60.63 |            91.030 |           9.10 |  1 day, 23:39:00 |    28     0     4  87.5 |
|     ANT/BUSD |     22 |           2.71 |          59.64 |            89.547 |           8.95 |  1 day, 10:16:00 |    21     0     1  95.5 |
|     DOT/BUSD |     15 |           3.74 |          56.16 |            84.321 |           8.43 |         15:32:00 |    15     0     0   100 |
|     PHA/BUSD |     11 |           5.08 |          55.86 |            83.875 |           8.39 |   1 day, 2:41:00 |    11     0     0   100 |
|     BEL/BUSD |     24 |           2.30 |          55.13 |            82.772 |           8.28 |         19:16:00 |    23     0     1  95.8 |
|     ATA/BUSD |     13 |           3.96 |          51.46 |            77.268 |           7.73 |  1 day, 10:27:00 |    12     0     1  92.3 |
|   ALPHA/BUSD |     31 |           1.55 |          48.03 |            72.120 |           7.21 |         18:12:00 |    28     0     3  90.3 |
|    RUNE/BUSD |     11 |           4.31 |          47.45 |            71.253 |           7.13 |         14:33:00 |    11     0     0   100 |
|     LIT/BUSD |     11 |           4.11 |          45.19 |            67.857 |           6.79 |         20:46:00 |    11     0     0   100 |
|     UFT/BUSD |     11 |           3.76 |          41.32 |            62.045 |           6.20 |         10:14:00 |    11     0     0   100 |
|     INJ/BUSD |     12 |           3.30 |          39.62 |            59.490 |           5.95 |         10:48:00 |    11     0     1  91.7 |
|     DGB/BUSD |     18 |           2.17 |          39.01 |            58.575 |           5.86 |   1 day, 0:00:00 |    17     0     1  94.4 |
|      AR/BUSD |     14 |           2.78 |          38.93 |            58.453 |           5.85 |         11:59:00 |    13     0     1  92.9 |
|    BAND/BUSD |     10 |           3.55 |          35.48 |            53.270 |           5.33 |  2 days, 7:36:00 |    10     0     0   100 |
|    LINA/BUSD |      7 |           4.49 |          31.45 |            47.224 |           4.72 |         11:26:00 |     7     0     0   100 |
|     TKO/BUSD |      5 |           6.23 |          31.15 |            46.774 |           4.68 |   1 day, 4:27:00 |     5     0     0   100 |
|      IQ/BUSD |     17 |           1.80 |          30.59 |            45.937 |           4.59 |         13:19:00 |    16     0     1  94.1 |
|    NEAR/BUSD |      9 |           3.40 |          30.57 |            45.905 |           4.59 |         18:22:00 |     9     0     0   100 |
|    DODO/BUSD |      9 |           3.33 |          29.94 |            44.950 |           4.49 |         12:28:00 |     9     0     0   100 |
|     LTC/BUSD |     10 |           2.99 |          29.86 |            44.841 |           4.48 |  2 days, 1:48:00 |    10     0     0   100 |
|     WRX/BUSD |      4 |           7.01 |          28.05 |            42.118 |           4.21 |          4:30:00 |     4     0     0   100 |
|    ALGO/BUSD |     30 |           0.90 |          26.93 |            40.439 |           4.04 |   1 day, 3:12:00 |    26     0     4  86.7 |
|    CTSI/BUSD |     12 |           2.21 |          26.51 |            39.805 |           3.98 |  2 days, 4:50:00 |    11     0     1  91.7 |
|   AUDIO/BUSD |     31 |           0.82 |          25.34 |            38.042 |           3.80 |  1 day, 11:56:00 |    27     0     4  87.1 |
|    LUNA/BUSD |     19 |           1.33 |          25.22 |            37.866 |           3.79 |  1 day, 19:05:00 |    16     0     3  84.2 |
|    PROM/BUSD |     25 |           0.88 |          22.05 |            33.113 |           3.31 |  1 day, 17:22:00 |    22     0     3  88.0 |
|     CRV/BUSD |     24 |           0.83 |          19.91 |            29.897 |           2.99 |  1 day, 12:36:00 |    21     0     3  87.5 |
|     XRP/BUSD |      5 |           3.55 |          17.74 |            26.636 |           2.66 |   1 day, 4:03:00 |     5     0     0   100 |
|   OCEAN/BUSD |      6 |           2.91 |          17.47 |            26.228 |           2.62 |          4:18:00 |     6     0     0   100 |
|    SAND/BUSD |      9 |           1.94 |          17.46 |            26.209 |           2.62 |   1 day, 1:13:00 |     8     0     1  88.9 |
|     SFP/BUSD |      6 |           2.88 |          17.30 |            25.969 |           2.60 |          3:40:00 |     6     0     0   100 |
|    ATOM/BUSD |     19 |           0.76 |          14.43 |            21.662 |           2.17 |         22:19:00 |    16     0     3  84.2 |
|    LINK/BUSD |      5 |           2.84 |          14.22 |            21.346 |           2.13 |   1 day, 2:39:00 |     5     0     0   100 |
|    PERP/BUSD |     10 |           1.30 |          12.96 |            19.453 |           1.95 |         11:10:00 |     9     0     1  90.0 |
|     ONE/BUSD |     12 |           1.04 |          12.49 |            18.761 |           1.88 |         16:20:00 |    10     0     2  83.3 |
|    STMX/BUSD |      3 |           3.82 |          11.45 |            17.191 |           1.72 |         14:55:00 |     3     0     0   100 |
|     FTM/BUSD |      3 |           3.66 |          10.98 |            16.488 |           1.65 |  1 day, 14:20:00 |     3     0     0   100 |
|   WAVES/BUSD |      4 |           2.73 |          10.92 |            16.403 |           1.64 |          9:34:00 |     4     0     0   100 |
|    BZRX/BUSD |     17 |           0.63 |          10.74 |            16.127 |           1.61 |         10:26:00 |    14     0     3  82.4 |
|     TWT/BUSD |      3 |           3.38 |          10.13 |            15.216 |           1.52 |         12:55:00 |     3     0     0   100 |
|    KEEP/BUSD |      3 |           3.37 |          10.11 |            15.175 |           1.52 |  3 days, 2:25:00 |     3     0     0   100 |
|     BTT/BUSD |      9 |           1.11 |          10.02 |            15.044 |           1.50 |   1 day, 0:33:00 |     8     0     1  88.9 |
|    AAVE/BUSD |     27 |           0.33 |           8.86 |            13.303 |           1.33 |  1 day, 13:13:00 |    23     0     4  85.2 |
| AUCTION/BUSD |     16 |           0.49 |           7.80 |            11.708 |           1.17 |         18:22:00 |    14     0     2  87.5 |
|     ZEC/BUSD |      2 |           3.12 |           6.23 |             9.360 |           0.94 |          2:38:00 |     2     0     0   100 |
|   SUSHI/BUSD |      7 |           0.84 |           5.86 |             8.805 |           0.88 |   1 day, 2:39:00 |     6     0     1  85.7 |
|    SHIB/BUSD |      1 |           5.83 |           5.83 |             8.750 |           0.88 |  1 day, 12:30:00 |     1     0     0   100 |
|    REEF/BUSD |      7 |           0.67 |           4.67 |             7.013 |           0.70 |         16:24:00 |     6     0     1  85.7 |
|   SUPER/BUSD |      8 |           0.54 |           4.33 |             6.505 |           0.65 |   1 day, 6:00:00 |     7     0     1  87.5 |
|     XVG/BUSD |      1 |           3.92 |           3.92 |             5.890 |           0.59 |          0:30:00 |     1     0     0   100 |
|    IOST/BUSD |      7 |           0.41 |           2.84 |             4.257 |           0.43 |          5:09:00 |     6     0     1  85.7 |
|     SKL/BUSD |      7 |           0.24 |           1.68 |             2.521 |           0.25 |         20:30:00 |     6     0     1  85.7 |
|     FIO/BUSD |     18 |           0.06 |           1.13 |             1.695 |           0.17 |   1 day, 8:47:00 |    15     0     3  83.3 |
|     KNC/BUSD |      8 |           0.12 |           0.92 |             1.389 |           0.14 |   1 day, 1:04:00 |     7     0     1  87.5 |
|     CTK/BUSD |     12 |           0.06 |           0.77 |             1.155 |           0.12 |  1 day, 14:12:00 |    10     0     2  83.3 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FIL/BUSD |     17 |          -0.02 |          -0.37 |            -0.553 |          -0.06 |   1 day, 8:55:00 |    14     0     3  82.4 |
|    POND/BUSD |      8 |          -0.12 |          -0.95 |            -1.429 |          -0.14 |         18:02:00 |     7     0     1  87.5 |
|    BAKE/BUSD |     18 |          -0.08 |          -1.46 |            -2.195 |          -0.22 |  1 day, 10:29:00 |    15     0     3  83.3 |
|     SXP/BUSD |      7 |          -0.31 |          -2.18 |            -3.279 |          -0.33 |         15:04:00 |     6     0     1  85.7 |
|    NANO/BUSD |      9 |          -0.28 |          -2.52 |            -3.787 |          -0.38 |  1 day, 23:05:00 |     7     0     2  77.8 |
|   1INCH/BUSD |     14 |          -0.21 |          -2.92 |            -4.386 |          -0.44 |         19:14:00 |    12     0     2  85.7 |
|   FRONT/BUSD |     22 |          -0.20 |          -4.50 |            -6.754 |          -0.68 |   1 day, 4:01:00 |    17     0     5  77.3 |
|    AVAX/BUSD |     19 |          -0.24 |          -4.56 |            -6.847 |          -0.68 |         20:24:00 |    16     0     3  84.2 |
|    POLS/BUSD |      5 |          -0.92 |          -4.60 |            -6.910 |          -0.69 |   1 day, 5:06:00 |     4     0     1  80.0 |
|    DOCK/BUSD |      5 |          -1.25 |          -6.27 |            -9.415 |          -0.94 |   1 day, 7:30:00 |     4     0     1  80.0 |
|    DASH/BUSD |     13 |          -0.53 |          -6.90 |           -10.360 |          -1.04 |   1 day, 0:17:00 |    11     0     2  84.6 |
|     GTC/BUSD |      4 |          -1.74 |          -6.97 |           -10.464 |          -1.05 |  2 days, 5:00:00 |     3     0     1  75.0 |
|     SRM/BUSD |      5 |          -1.47 |          -7.35 |           -11.040 |          -1.10 |  1 day, 15:12:00 |     4     0     1  80.0 |
|     XTZ/BUSD |      5 |          -1.51 |          -7.54 |           -11.317 |          -1.13 |  1 day, 17:03:00 |     4     0     1  80.0 |
|     RSR/BUSD |      9 |          -0.87 |          -7.81 |           -11.726 |          -1.17 |   1 day, 2:02:00 |     7     0     2  77.8 |
|     ZIL/BUSD |      4 |          -2.02 |          -8.08 |           -12.134 |          -1.21 |         10:41:00 |     3     0     1  75.0 |
|    IOTX/BUSD |      4 |          -2.04 |          -8.15 |           -12.240 |          -1.22 |         20:00:00 |     3     0     1  75.0 |
|    EGLD/BUSD |     18 |          -0.45 |          -8.16 |           -12.250 |          -1.23 |   1 day, 9:04:00 |    15     0     3  83.3 |
|     MIR/BUSD |     12 |          -0.69 |          -8.25 |           -12.386 |          -1.24 | 2 days, 19:54:00 |     9     0     3  75.0 |
|     KSM/BUSD |     13 |          -0.71 |          -9.20 |           -13.811 |          -1.38 |         14:58:00 |    11     0     2  84.6 |
|     YFI/BUSD |      4 |          -2.40 |          -9.59 |           -14.400 |          -1.44 |  1 day, 21:08:00 |     3     0     1  75.0 |
|     TVK/BUSD |      4 |          -2.44 |          -9.76 |           -14.659 |          -1.47 |   1 day, 2:19:00 |     3     0     1  75.0 |
|     SOL/BUSD |      4 |          -2.56 |         -10.25 |           -15.392 |          -1.54 | 2 days, 16:30:00 |     3     0     1  75.0 |
|    COTI/BUSD |      3 |          -3.66 |         -10.99 |           -16.500 |          -1.65 |   1 day, 8:45:00 |     2     0     1  66.7 |
|    MANA/BUSD |     10 |          -1.25 |         -12.55 |           -18.840 |          -1.88 |  1 day, 23:22:00 |     8     0     2  80.0 |
|     SNX/BUSD |      3 |          -4.93 |         -14.79 |           -22.211 |          -2.22 |   1 day, 7:55:00 |     2     0     1  66.7 |
|     ICP/BUSD |      8 |          -1.90 |         -15.22 |           -22.860 |          -2.29 |   1 day, 1:09:00 |     6     0     2  75.0 |
|     GRT/BUSD |      7 |          -2.19 |         -15.31 |           -22.986 |          -2.30 |  2 days, 7:06:00 |     5     0     2  71.4 |
|     CVP/BUSD |     18 |          -0.95 |         -17.15 |           -25.752 |          -2.58 |  1 day, 21:50:00 |    14     0     4  77.8 |
|     BCH/BUSD |     22 |          -0.90 |         -19.83 |           -29.782 |          -2.98 |  1 day, 12:36:00 |    18     0     4  81.8 |
|     UNI/BUSD |      8 |          -2.92 |         -23.32 |           -35.018 |          -3.50 |  2 days, 4:06:00 |     6     0     2  75.0 |
|     HOT/BUSD |      6 |          -4.46 |         -26.77 |           -40.188 |          -4.02 |  1 day, 10:32:00 |     4     0     2  66.7 |
|     MKR/BUSD |     12 |          -2.23 |         -26.81 |           -40.250 |          -4.02 | 3 days, 16:39:00 |     9     0     3  75.0 |
|    IDEX/BUSD |     10 |          -2.81 |         -28.09 |           -42.176 |          -4.22 |  2 days, 1:24:00 |     7     0     3  70.0 |
|     EPS/BUSD |     11 |          -2.76 |         -30.36 |           -45.584 |          -4.56 |         21:00:00 |     8     0     3  72.7 |
|     MDX/BUSD |      5 |          -6.33 |         -31.67 |           -47.557 |          -4.76 |  4 days, 6:12:00 |     3     0     2  60.0 |
|   MATIC/BUSD |      9 |          -3.72 |         -33.52 |           -50.329 |          -5.03 |         22:38:00 |     6     0     3  66.7 |
|   FORTH/BUSD |      9 |          -3.74 |         -33.70 |           -50.596 |          -5.06 |   1 day, 8:17:00 |     6     0     3  66.7 |
|     ENJ/BUSD |     16 |          -2.16 |         -34.56 |           -51.892 |          -5.19 |         19:50:00 |    12     0     4  75.0 |
|    DEGO/BUSD |     10 |          -3.88 |         -38.80 |           -58.260 |          -5.83 |  1 day, 22:56:00 |     7     0     3  70.0 |
|    DATA/BUSD |     17 |          -2.53 |         -43.05 |           -64.636 |          -6.46 |  1 day, 21:24:00 |    10     0     7  58.8 |
|   ALICE/BUSD |     16 |          -2.76 |         -44.18 |           -66.337 |          -6.63 |   1 day, 5:34:00 |    12     0     4  75.0 |
|     TLM/BUSD |      7 |          -6.56 |         -45.95 |           -69.000 |          -6.90 |         15:54:00 |     4     0     3  57.1 |
|    COMP/BUSD |     25 |          -2.44 |         -60.95 |           -91.516 |          -9.15 |  1 day, 13:47:00 |    19     0     6  76.0 |
|     XVS/BUSD |     17 |          -4.26 |         -72.47 |          -108.815 |         -10.88 |         12:53:00 |    11     0     6  64.7 |
|    DOGE/BUSD |     22 |          -3.63 |         -79.77 |          -119.776 |         -11.98 |  1 day, 23:35:00 |    15     0     7  68.2 |
|     FXS/BUSD |     22 |          -5.08 |        -111.83 |          -167.914 |         -16.79 |  2 days, 8:45:00 |    14     0     8  63.6 |
|        TOTAL |   1325 |           0.48 |         638.65 |           958.926 |          95.89 |   1 day, 6:08:00 |  1128     0   197  85.1 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |    1128 |   1128     0     0   100 |           4.02 |        4538.06 |          6813.9   |         756.34 |
|          stop_loss |     191 |      0     0   191     0 |         -20.16 |       -3850.88 |         -5782.1   |        -641.81 |
|         force_sell |       6 |      0     0     6     0 |          -8.09 |         -48.53 |           -72.868 |          -8.09 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|  ATOM/BUSD |      1 |          -3.78 |          -3.78 |            -5.674 |          -0.57 |  3 days, 0:00:00 |     0     0     1     0 |
| CREAM/BUSD |      1 |          -5.36 |          -5.36 |            -8.042 |          -0.80 |  9 days, 9:00:00 |     0     0     1     0 |
| FRONT/BUSD |      1 |          -7.50 |          -7.50 |           -11.262 |          -1.13 | 5 days, 21:15:00 |     0     0     1     0 |
|  ALGO/BUSD |      1 |          -8.94 |          -8.94 |           -13.425 |          -1.34 |  2 days, 4:00:00 |     0     0     1     0 |
| ALPHA/BUSD |      1 |          -9.52 |          -9.52 |           -14.289 |          -1.43 | 2 days, 23:30:00 |     0     0     1     0 |
|   BEL/BUSD |      1 |         -13.44 |         -13.44 |           -20.177 |          -2.02 |  5 days, 9:00:00 |     0     0     1     0 |
|      TOTAL |      6 |          -8.09 |         -48.53 |           -72.868 |          -7.29 | 4 days, 19:08:00 |     0     0     6     0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-01-01 00:00:00 |
| Backtesting to         | 2021-10-12 16:15:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 1325 / 4.67         |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1958.926 BUSD       |
| Absolute profit        | 958.926 BUSD        |
| Total profit %         | 95.89%              |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 198750.000 BUSD     |
|                        |                     |
| Best Pair              | AERGO/BUSD 96.91%   |
| Worst Pair             | FXS/BUSD -111.83%   |
| Best trade             | DATA/BUSD 55.16%    |
| Worst trade            | CVP/BUSD -20.48%    |
| Best day               | 185.423 BUSD        |
| Worst day              | -258.466 BUSD       |
| Days win/draw/lose     | 186 / 30 / 69       |
| Avg. Duration Winners  | 23:01:00            |
| Avg. Duration Loser    | 2 days, 22:54:00    |
| Rejected Buy signals   | 2206954             |
|                        |                     |
| Min balance            | 1004.209 BUSD       |
| Max balance            | 2140.366 BUSD       |
| Drawdown               | 597.06%             |
| Drawdown               | 896.479 BUSD        |
| Drawdown high          | 1140.366 BUSD       |
| Drawdown low           | 243.887 BUSD        |
| Drawdown Start         | 2021-02-20 13:45:00 |
| Drawdown End           | 2021-06-22 14:00:00 |
| Market change          | 748.84%             |
================================================

Result for strategy Apollo11_3
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|     AXS/BUSD |     23 |           5.19 |         119.27 |           179.084 |          17.91 |         10:01:00 |    23     0     0   100 |
|    DEXE/BUSD |     41 |           2.13 |          87.41 |           131.253 |          13.13 |   1 day, 3:34:00 |    36     0     5  87.8 |
|   CREAM/BUSD |     33 |           2.14 |          70.76 |           106.245 |          10.62 |   1 day, 8:35:00 |    29     0     4  87.9 |
|     INJ/BUSD |     17 |           4.15 |          70.62 |           106.040 |          10.60 |   1 day, 0:11:00 |    17     0     0   100 |
|   AERGO/BUSD |     42 |           1.58 |          66.56 |            99.947 |           9.99 |   1 day, 0:32:00 |    39     0     3  92.9 |
|     AVA/BUSD |     20 |           3.00 |          59.97 |            90.043 |           9.00 |   1 day, 6:45:00 |    19     0     1  95.0 |
|   AUDIO/BUSD |     35 |           1.56 |          54.74 |            82.189 |           8.22 |   1 day, 9:55:00 |    32     0     3  91.4 |
|     ANT/BUSD |     21 |           2.55 |          53.63 |            80.523 |           8.05 |   1 day, 8:55:00 |    20     0     1  95.2 |
|   FRONT/BUSD |     17 |           3.12 |          53.07 |            79.689 |           7.97 |         18:22:00 |    15     0     2  88.2 |
|     DOT/BUSD |     16 |           3.24 |          51.83 |            77.817 |           7.78 |          8:23:00 |    16     0     0   100 |
|    AVAX/BUSD |     28 |           1.71 |          47.79 |            71.761 |           7.18 |         11:38:00 |    26     0     2  92.9 |
|     ATA/BUSD |     16 |           2.96 |          47.38 |            71.142 |           7.11 |         11:38:00 |    15     0     1  93.8 |
|      IQ/BUSD |     23 |           2.05 |          47.06 |            70.665 |           7.07 |   1 day, 5:04:00 |    22     0     1  95.7 |
|    LUNA/BUSD |     15 |           2.74 |          41.03 |            61.602 |           6.16 |         18:14:00 |    14     0     1  93.3 |
|    COTI/BUSD |      6 |           6.65 |          39.88 |            59.884 |           5.99 |   1 day, 5:55:00 |     5     0     1  83.3 |
|   ALPHA/BUSD |     23 |           1.70 |          39.19 |            58.843 |           5.88 |         17:37:00 |    21     0     2  91.3 |
|    LINA/BUSD |      8 |           4.83 |          38.61 |            57.977 |           5.80 |          9:38:00 |     8     0     0   100 |
|     BEL/BUSD |     25 |           1.51 |          37.82 |            56.787 |           5.68 |         23:04:00 |    23     0     2  92.0 |
|    HARD/BUSD |     21 |           1.77 |          37.18 |            55.822 |           5.58 |         19:54:00 |    19     0     2  90.5 |
|     WRX/BUSD |      8 |           4.49 |          35.95 |            53.986 |           5.40 |   1 day, 0:45:00 |     8     0     0   100 |
|    IOST/BUSD |      9 |           3.96 |          35.63 |            53.498 |           5.35 |         14:25:00 |     9     0     0   100 |
|     CTK/BUSD |     18 |           1.96 |          35.22 |            52.882 |           5.29 |   1 day, 1:13:00 |    17     0     1  94.4 |
|     CRV/BUSD |     18 |           1.88 |          33.77 |            50.707 |           5.07 |         17:34:00 |    17     0     1  94.4 |
|     PHA/BUSD |     17 |           1.94 |          33.03 |            49.596 |           4.96 |  1 day, 11:04:00 |    15     0     2  88.2 |
|    ALGO/BUSD |     35 |           0.90 |          31.48 |            47.269 |           4.73 |   1 day, 3:43:00 |    32     0     3  91.4 |
|    PROM/BUSD |     24 |           1.29 |          30.97 |            46.501 |           4.65 |  1 day, 12:15:00 |    22     0     2  91.7 |
|    SAND/BUSD |     13 |           2.20 |          28.58 |            42.907 |           4.29 |         21:38:00 |    12     0     1  92.3 |
|     HOT/BUSD |      6 |           4.51 |          27.07 |            40.645 |           4.06 |         16:52:00 |     6     0     0   100 |
|     LTC/BUSD |      9 |           2.99 |          26.94 |            40.457 |           4.05 |   1 day, 6:03:00 |     9     0     0   100 |
|     TKO/BUSD |      6 |           4.26 |          25.56 |            38.381 |           3.84 |  1 day, 21:00:00 |     6     0     0   100 |
|      AR/BUSD |      8 |           3.03 |          24.25 |            36.412 |           3.64 |          8:51:00 |     8     0     0   100 |
|     UFT/BUSD |     13 |           1.81 |          23.50 |            35.288 |           3.53 |         22:27:00 |    12     0     1  92.3 |
|    RUNE/BUSD |     12 |           1.91 |          22.88 |            34.350 |           3.43 |         13:45:00 |    11     0     1  91.7 |
|     XRP/BUSD |      6 |           3.72 |          22.31 |            33.494 |           3.35 |         13:32:00 |     6     0     0   100 |
|     SXP/BUSD |      8 |           2.76 |          22.08 |            33.146 |           3.31 |          6:00:00 |     8     0     0   100 |
|   ALICE/BUSD |     23 |           0.93 |          21.41 |            32.143 |           3.21 |         17:33:00 |    21     0     2  91.3 |
|    CTSI/BUSD |     16 |           1.25 |          19.92 |            29.914 |           2.99 |         17:18:00 |    15     0     1  93.8 |
|   SUSHI/BUSD |      5 |           3.83 |          19.13 |            28.723 |           2.87 |         12:12:00 |     5     0     0   100 |
|    BAKE/BUSD |     21 |           0.88 |          18.44 |            27.687 |           2.77 |   1 day, 6:12:00 |    19     0     2  90.5 |
|     LIT/BUSD |     12 |           1.52 |          18.25 |            27.396 |           2.74 |   1 day, 9:59:00 |    11     0     1  91.7 |
|    IOTX/BUSD |      5 |           3.42 |          17.09 |            25.654 |           2.57 |   1 day, 5:54:00 |     5     0     0   100 |
|   MATIC/BUSD |     10 |           1.54 |          15.40 |            23.118 |           2.31 |         10:18:00 |     9     0     1  90.0 |
|   1INCH/BUSD |     22 |           0.70 |          15.32 |            23.005 |           2.30 |         10:04:00 |    19     0     3  86.4 |
|     KSM/BUSD |     12 |           1.24 |          14.87 |            22.333 |           2.23 |         12:21:00 |    11     0     1  91.7 |
|    ATOM/BUSD |     21 |           0.68 |          14.19 |            21.310 |           2.13 |   1 day, 7:56:00 |    18     0     3  85.7 |
|     ZEC/BUSD |      5 |           2.74 |          13.70 |            20.566 |           2.06 |         12:18:00 |     5     0     0   100 |
|    POND/BUSD |      5 |           2.54 |          12.69 |            19.048 |           1.90 |          3:24:00 |     5     0     0   100 |
|     DGB/BUSD |     14 |           0.89 |          12.41 |            18.639 |           1.86 |  1 day, 22:30:00 |    13     0     1  92.9 |
|     KNC/BUSD |     11 |           1.02 |          11.17 |            16.765 |           1.68 |         13:19:00 |    10     0     1  90.9 |
| AUCTION/BUSD |     21 |           0.52 |          10.94 |            16.420 |           1.64 |   1 day, 0:48:00 |    18     0     3  85.7 |
|    POLS/BUSD |      3 |           3.57 |          10.72 |            16.096 |           1.61 |  1 day, 11:05:00 |     3     0     0   100 |
|    BZRX/BUSD |     16 |           0.56 |           9.02 |            13.548 |           1.35 |          6:09:00 |    14     0     2  87.5 |
|     FTM/BUSD |      3 |           2.79 |           8.38 |            12.577 |           1.26 |   1 day, 6:20:00 |     3     0     0   100 |
|    SHIB/BUSD |      2 |           4.13 |           8.26 |            12.398 |           1.24 |         19:52:00 |     2     0     0   100 |
|    EGLD/BUSD |     15 |           0.52 |           7.86 |            11.801 |           1.18 |         21:57:00 |    13     0     2  86.7 |
|    STMX/BUSD |      3 |           2.43 |           7.29 |            10.953 |           1.10 |         14:45:00 |     3     0     0   100 |
|     SFP/BUSD |     10 |           0.69 |           6.93 |            10.405 |           1.04 |   1 day, 3:44:00 |     9     0     1  90.0 |
|    MANA/BUSD |     11 |           0.55 |           6.03 |             9.057 |           0.91 |  1 day, 13:30:00 |    10     0     1  90.9 |
|   THETA/BUSD |      2 |           2.20 |           4.40 |             6.604 |           0.66 |  3 days, 9:08:00 |     2     0     0   100 |
|     XVG/BUSD |      2 |           2.10 |           4.20 |             6.303 |           0.63 | 2 days, 23:30:00 |     2     0     0   100 |
|    REEF/BUSD |      6 |           0.68 |           4.08 |             6.125 |           0.61 |   1 day, 3:32:00 |     5     0     1  83.3 |
|    PERP/BUSD |     12 |           0.20 |           2.43 |             3.651 |           0.37 |         21:05:00 |    10     0     2  83.3 |
|    LINK/BUSD |      9 |           0.21 |           1.93 |             2.903 |           0.29 |   1 day, 9:20:00 |     8     0     1  88.9 |
|    NEAR/BUSD |      7 |           0.26 |           1.81 |             2.724 |           0.27 |         11:41:00 |     6     0     1  85.7 |
|     SNX/BUSD |      4 |           0.37 |           1.50 |             2.251 |           0.23 |  2 days, 2:52:00 |     3     0     1  75.0 |
|     SKL/BUSD |      8 |           0.13 |           1.02 |             1.533 |           0.15 |  1 day, 13:49:00 |     7     0     1  87.5 |
|   SUPER/BUSD |      8 |           0.00 |           0.02 |             0.023 |           0.00 |   1 day, 9:24:00 |     7     0     1  87.5 |
|    AAVE/BUSD |     27 |          -0.07 |          -1.85 |            -2.778 |          -0.28 |  2 days, 1:51:00 |    23     0     4  85.2 |
|     BCH/BUSD |     19 |          -0.33 |          -6.33 |            -9.508 |          -0.95 |  1 day, 12:25:00 |    16     0     3  84.2 |
|     SOL/BUSD |      5 |          -1.50 |          -7.48 |           -11.229 |          -1.12 |  2 days, 4:06:00 |     4     0     1  80.0 |
|     ONE/BUSD |     11 |          -0.76 |          -8.32 |           -12.499 |          -1.25 |         23:12:00 |     9     0     2  81.8 |
|     ZIL/BUSD |      5 |          -1.83 |          -9.17 |           -13.766 |          -1.38 |          8:57:00 |     4     0     1  80.0 |
|     FIL/BUSD |     21 |          -0.56 |         -11.77 |           -17.669 |          -1.77 |   1 day, 5:29:00 |    17     0     4  81.0 |
|    DOCK/BUSD |      3 |          -4.08 |         -12.23 |           -18.370 |          -1.84 |  1 day, 13:00:00 |     2     0     1  66.7 |
|     YFI/BUSD |      5 |          -2.51 |         -12.54 |           -18.831 |          -1.88 | 4 days, 17:21:00 |     4     0     1  80.0 |
|    KEEP/BUSD |      3 |          -4.66 |         -13.97 |           -20.981 |          -2.10 |  1 day, 14:35:00 |     2     0     1  66.7 |
|     UNI/BUSD |      3 |          -5.13 |         -15.40 |           -23.122 |          -2.31 |  3 days, 6:50:00 |     2     0     1  66.7 |
|     MIR/BUSD |     12 |          -1.33 |         -15.92 |           -23.900 |          -2.39 | 2 days, 18:11:00 |     9     0     3  75.0 |
|    DODO/BUSD |     10 |          -1.62 |         -16.23 |           -24.365 |          -2.44 |         18:57:00 |     8     0     2  80.0 |
|     MKR/BUSD |     11 |          -1.50 |         -16.45 |           -24.706 |          -2.47 |  3 days, 2:48:00 |     9     0     2  81.8 |
|    BAND/BUSD |      9 |          -1.96 |         -17.63 |           -26.476 |          -2.65 |   1 day, 3:22:00 |     7     0     2  77.8 |
|     XVS/BUSD |     19 |          -1.02 |         -19.42 |           -29.165 |          -2.92 |         12:40:00 |    15     0     4  78.9 |
|     FIO/BUSD |     18 |          -1.14 |         -20.47 |           -30.736 |          -3.07 |         23:28:00 |    14     0     4  77.8 |
|     RSR/BUSD |      7 |          -3.07 |         -21.47 |           -32.243 |          -3.22 |         14:00:00 |     5     0     2  71.4 |
|     GRT/BUSD |      8 |          -2.83 |         -22.65 |           -34.013 |          -3.40 |  1 day, 13:58:00 |     6     0     2  75.0 |
|     BTT/BUSD |     13 |          -1.81 |         -23.54 |           -35.340 |          -3.53 |         20:28:00 |    10     0     3  76.9 |
|    DEGO/BUSD |     11 |          -2.17 |         -23.88 |           -35.852 |          -3.59 |  1 day, 17:12:00 |     8     0     3  72.7 |
|   FORTH/BUSD |     13 |          -1.87 |         -24.33 |           -36.526 |          -3.65 |  2 days, 2:21:00 |    10     0     3  76.9 |
|     TLM/BUSD |      6 |          -4.32 |         -25.94 |           -38.954 |          -3.90 |         12:50:00 |     4     0     2  66.7 |
|     XTZ/BUSD |      7 |          -3.80 |         -26.62 |           -39.963 |          -4.00 |   1 day, 5:28:00 |     5     0     2  71.4 |
|     TWT/BUSD |      8 |          -3.34 |         -26.75 |           -40.162 |          -4.02 |   1 day, 3:26:00 |     6     0     2  75.0 |
|    NANO/BUSD |     11 |          -2.43 |         -26.77 |           -40.201 |          -4.02 | 2 days, 13:00:00 |     8     0     3  72.7 |
|     GTC/BUSD |      6 |          -4.72 |         -28.31 |           -42.511 |          -4.25 |  1 day, 16:50:00 |     4     0     2  66.7 |
|    COMP/BUSD |     22 |          -1.30 |         -28.62 |           -42.977 |          -4.30 |   1 day, 2:03:00 |    18     0     4  81.8 |
|     TVK/BUSD |      6 |          -4.81 |         -28.85 |           -43.320 |          -4.33 |   1 day, 7:20:00 |     4     0     2  66.7 |
|     MDX/BUSD |      4 |          -7.50 |         -29.99 |           -45.037 |          -4.50 | 3 days, 15:26:00 |     2     0     2  50.0 |
|   WAVES/BUSD |     12 |          -2.81 |         -33.69 |           -50.588 |          -5.06 |         16:20:00 |     9     0     3  75.0 |
|     CVP/BUSD |     21 |          -1.62 |         -34.07 |           -51.152 |          -5.12 |   1 day, 6:29:00 |    17     0     4  81.0 |
|   OCEAN/BUSD |     12 |          -3.07 |         -36.87 |           -55.360 |          -5.54 |         11:08:00 |     9     0     3  75.0 |
|     ICP/BUSD |     11 |          -3.44 |         -37.85 |           -56.825 |          -5.68 |   1 day, 2:15:00 |     8     0     3  72.7 |
|     FXS/BUSD |     25 |          -1.58 |         -39.44 |           -59.219 |          -5.92 |  1 day, 13:10:00 |    20     0     5  80.0 |
|     SRM/BUSD |      3 |         -13.18 |         -39.54 |           -59.369 |          -5.94 |  1 day, 12:55:00 |     1     0     2  33.3 |
|    DASH/BUSD |     15 |          -2.90 |         -43.46 |           -65.253 |          -6.53 |   1 day, 7:02:00 |    11     0     4  73.3 |
|    DOGE/BUSD |     27 |          -1.68 |         -45.41 |           -68.178 |          -6.82 |         23:38:00 |    20     0     7  74.1 |
|    IDEX/BUSD |     16 |          -2.88 |         -46.09 |           -69.202 |          -6.92 |  1 day, 20:50:00 |    12     0     4  75.0 |
|    DATA/BUSD |     19 |          -3.08 |         -58.56 |           -87.925 |          -8.79 |  1 day, 12:36:00 |    14     0     5  73.7 |
|     EPS/BUSD |     15 |          -4.90 |         -73.55 |          -110.436 |         -11.04 |   1 day, 1:40:00 |    10     0     5  66.7 |
|     ENJ/BUSD |     13 |          -7.43 |         -96.59 |          -145.023 |         -14.50 |  1 day, 20:16:00 |     7     0     6  53.8 |
|        TOTAL |   1456 |           0.49 |         715.80 |          1074.775 |         107.48 |   1 day, 3:22:00 |  1261     0   195  86.6 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |    1261 |   1261     0     0   100 |           3.63 |        4573.74 |          6867.47  |         762.29 |
|          stop_loss |     189 |      0     0   189     0 |         -20.16 |       -3810.56 |         -5721.56  |        -635.09 |
|         force_sell |       6 |      0     0     6     0 |          -7.9  |         -47.38 |           -71.135 |          -7.9  |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|  ATOM/BUSD |      1 |          -3.78 |          -3.78 |            -5.674 |          -0.57 |  3 days, 0:00:00 |     0     0     1     0 |
| CREAM/BUSD |      1 |          -5.36 |          -5.36 |            -8.042 |          -0.80 |  9 days, 9:00:00 |     0     0     1     0 |
|   SNX/BUSD |      1 |          -7.21 |          -7.21 |           -10.821 |          -1.08 | 5 days, 14:45:00 |     0     0     1     0 |
|  DEGO/BUSD |      1 |          -7.71 |          -7.71 |           -11.575 |          -1.16 |  4 days, 2:45:00 |     0     0     1     0 |
| ALPHA/BUSD |      1 |          -9.52 |          -9.52 |           -14.289 |          -1.43 | 2 days, 23:30:00 |     0     0     1     0 |
|  ALGO/BUSD |      1 |         -13.81 |         -13.81 |           -20.734 |          -2.07 | 4 days, 13:45:00 |     0     0     1     0 |
|      TOTAL |      6 |          -7.90 |         -47.38 |           -71.135 |          -7.11 | 4 days, 22:38:00 |     0     0     6     0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-01-01 00:00:00 |
| Backtesting to         | 2021-10-12 16:15:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 1456 / 5.13         |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 2074.775 BUSD       |
| Absolute profit        | 1074.775 BUSD       |
| Total profit %         | 107.48%             |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 218400.000 BUSD     |
|                        |                     |
| Best Pair              | AXS/BUSD 119.27%    |
| Worst Pair             | ENJ/BUSD -96.59%    |
| Best trade             | COTI/BUSD 47.64%    |
| Worst trade            | CVP/BUSD -20.48%    |
| Best day               | 176.368 BUSD        |
| Worst day              | -282.202 BUSD       |
| Days win/draw/lose     | 196 / 19 / 70       |
| Avg. Duration Winners  | 21:31:00            |
| Avg. Duration Loser    | 2 days, 17:09:00    |
| Rejected Buy signals   | 2190723             |
|                        |                     |
| Min balance            | 1004.209 BUSD       |
| Max balance            | 2180.993 BUSD       |
| Drawdown               | 584.3%              |
| Drawdown               | 877.325 BUSD        |
| Drawdown high          | 1052.675 BUSD       |
| Drawdown low           | 175.350 BUSD        |
| Drawdown Start         | 2021-05-08 18:45:00 |
| Drawdown End           | 2021-06-22 13:45:00 |
| Market change          | 748.84%             |
================================================

2021-01-01 00:00:00 -> 2021-10-12 16:15:00 | Max open trades : 6
======================================================================== STRATEGY SUMMARY =======================================================================
|   Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |   Avg Duration |   Win  Draw  Loss  Win% |              Drawdown |
|------------+--------+----------------+----------------+-------------------+----------------+----------------+-------------------------+-----------------------|
|   Apollo11 |   1325 |           0.48 |         638.65 |           958.926 |          95.89 | 1 day, 6:08:00 |  1128     0   197  85.1 | 896.479 BUSD  597.06% |
| Apollo11_3 |   1456 |           0.49 |         715.80 |          1074.775 |         107.48 | 1 day, 3:22:00 |  1261     0   195  86.6 | 877.325 BUSD  584.30% |
=================================================================================================================================================================
```
# August
```
Result for strategy Apollo11
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|     ATA/BUSD |      4 |           7.68 |          30.72 |            46.123 |           4.61 |         14:49:00 |     4     0     0   100 |
| AUCTION/BUSD |      5 |           4.14 |          20.72 |            31.107 |           3.11 |         16:09:00 |     5     0     0   100 |
|   AUDIO/BUSD |      2 |           9.22 |          18.44 |            27.688 |           2.77 |          7:45:00 |     2     0     0   100 |
|     AXS/BUSD |      3 |           5.51 |          16.52 |            24.811 |           2.48 |   1 day, 0:45:00 |     3     0     0   100 |
|   ALPHA/BUSD |      3 |           5.41 |          16.24 |            24.384 |           2.44 |   1 day, 2:55:00 |     3     0     0   100 |
|     FIO/BUSD |      1 |          15.83 |          15.83 |            23.770 |           2.38 | 4 days, 22:00:00 |     1     0     0   100 |
|    DATA/BUSD |      4 |           3.88 |          15.53 |            23.319 |           2.33 |         14:26:00 |     4     0     0   100 |
|    KEEP/BUSD |      2 |           5.60 |          11.21 |            16.824 |           1.68 |  1 day, 17:15:00 |     2     0     0   100 |
|   ALICE/BUSD |      4 |           2.30 |           9.22 |            13.840 |           1.38 |         11:11:00 |     3     0     1  75.0 |
|    RUNE/BUSD |      2 |           4.35 |           8.71 |            13.077 |           1.31 |         11:38:00 |     2     0     0   100 |
|     ANT/BUSD |      1 |           8.00 |           8.00 |            12.006 |           1.20 | 6 days, 11:30:00 |     1     0     0   100 |
|     BEL/BUSD |      1 |           7.75 |           7.75 |            11.630 |           1.16 |  2 days, 0:30:00 |     1     0     0   100 |
|    DEXE/BUSD |      3 |           2.50 |           7.51 |            11.282 |           1.13 |         15:40:00 |     3     0     0   100 |
|     AVA/BUSD |      1 |           7.18 |           7.18 |            10.782 |           1.08 |  1 day, 13:45:00 |     1     0     0   100 |
|   FRONT/BUSD |      1 |           7.01 |           7.01 |            10.530 |           1.05 |  1 day, 15:15:00 |     1     0     0   100 |
|      IQ/BUSD |      2 |           3.39 |           6.78 |            10.187 |           1.02 | 2 days, 21:22:00 |     2     0     0   100 |
|     FIL/BUSD |      1 |           6.60 |           6.60 |             9.913 |           0.99 |   1 day, 7:15:00 |     1     0     0   100 |
|    COTI/BUSD |      2 |           3.29 |           6.59 |             9.893 |           0.99 |   1 day, 0:22:00 |     2     0     0   100 |
|     MIR/BUSD |      2 |           3.18 |           6.36 |             9.550 |           0.95 |         11:22:00 |     2     0     0   100 |
|     EPS/BUSD |      2 |           3.15 |           6.31 |             9.471 |           0.95 |          9:52:00 |     2     0     0   100 |
|    POLS/BUSD |      2 |           2.93 |           5.86 |             8.802 |           0.88 |         15:30:00 |     2     0     0   100 |
|    LINA/BUSD |      2 |           2.77 |           5.55 |             8.330 |           0.83 |          5:30:00 |     2     0     0   100 |
|    PROM/BUSD |      2 |           2.73 |           5.47 |             8.206 |           0.82 |          5:08:00 |     2     0     0   100 |
|     PHA/BUSD |      1 |           5.30 |           5.30 |             7.953 |           0.80 | 2 days, 22:30:00 |     1     0     0   100 |
|     ENJ/BUSD |      2 |           2.61 |           5.21 |             7.824 |           0.78 |   1 day, 4:00:00 |     2     0     0   100 |
|     FXS/BUSD |      1 |           4.95 |           4.95 |             7.426 |           0.74 |         17:15:00 |     1     0     0   100 |
|     GTC/BUSD |      1 |           4.80 |           4.80 |             7.211 |           0.72 |          3:30:00 |     1     0     0   100 |
|    STMX/BUSD |      1 |           4.66 |           4.66 |             7.002 |           0.70 |         13:45:00 |     1     0     0   100 |
|   WAVES/BUSD |      1 |           4.66 |           4.66 |             7.000 |           0.70 |          4:30:00 |     1     0     0   100 |
|     KSM/BUSD |      1 |           4.66 |           4.66 |             6.992 |           0.70 |         11:15:00 |     1     0     0   100 |
|    IDEX/BUSD |      1 |           4.61 |           4.61 |             6.922 |           0.69 |  4 days, 0:45:00 |     1     0     0   100 |
|     DGB/BUSD |      2 |           2.28 |           4.57 |             6.861 |           0.69 |   1 day, 6:38:00 |     2     0     0   100 |
|     TKO/BUSD |      1 |           4.34 |           4.34 |             6.509 |           0.65 |          8:45:00 |     1     0     0   100 |
|     CVP/BUSD |      1 |           4.15 |           4.15 |             6.234 |           0.62 | 6 days, 18:30:00 |     1     0     0   100 |
|    BAKE/BUSD |      1 |           3.75 |           3.75 |             5.627 |           0.56 |         13:30:00 |     1     0     0   100 |
|     UFT/BUSD |      1 |           3.71 |           3.71 |             5.578 |           0.56 |   1 day, 6:15:00 |     1     0     0   100 |
|   AERGO/BUSD |      1 |           3.41 |           3.41 |             5.122 |           0.51 |         13:15:00 |     1     0     0   100 |
|    AAVE/BUSD |      1 |           3.21 |           3.21 |             4.827 |           0.48 |  2 days, 6:30:00 |     1     0     0   100 |
|    DOGE/BUSD |      1 |           2.95 |           2.95 |             4.435 |           0.44 |         10:15:00 |     1     0     0   100 |
|    ATOM/BUSD |      1 |           2.89 |           2.89 |             4.332 |           0.43 |         19:30:00 |     1     0     0   100 |
|     HOT/BUSD |      1 |           2.85 |           2.85 |             4.284 |           0.43 |          7:00:00 |     1     0     0   100 |
|   OCEAN/BUSD |      1 |           2.83 |           2.83 |             4.255 |           0.43 |          8:00:00 |     1     0     0   100 |
|     TVK/BUSD |      1 |           2.82 |           2.82 |             4.229 |           0.42 |   1 day, 2:45:00 |     1     0     0   100 |
|    DEGO/BUSD |      1 |           2.66 |           2.66 |             3.989 |           0.40 | 11 days, 9:00:00 |     1     0     0   100 |
|      AR/BUSD |      1 |           2.58 |           2.58 |             3.869 |           0.39 |          7:45:00 |     1     0     0   100 |
|     INJ/BUSD |      1 |           2.34 |           2.34 |             3.508 |           0.35 | 2 days, 18:45:00 |     1     0     0   100 |
|     FTM/BUSD |      1 |           2.33 |           2.33 |             3.494 |           0.35 |  3 days, 1:30:00 |     1     0     0   100 |
|     SKL/BUSD |      1 |           2.30 |           2.30 |             3.456 |           0.35 |   1 day, 2:45:00 |     1     0     0   100 |
|    ALGO/BUSD |      1 |           2.26 |           2.26 |             3.389 |           0.34 |          8:45:00 |     1     0     0   100 |
|     LTC/BUSD |      1 |           2.17 |           2.17 |             3.255 |           0.33 | 6 days, 15:30:00 |     1     0     0   100 |
|    COMP/BUSD |      1 |           2.16 |           2.16 |             3.244 |           0.32 |  1 day, 21:00:00 |     1     0     0   100 |
|    CTSI/BUSD |      1 |           2.12 |           2.12 |             3.183 |           0.32 |  4 days, 7:00:00 |     1     0     0   100 |
|     SNX/BUSD |      1 |           2.06 |           2.06 |             3.098 |           0.31 |          3:30:00 |     1     0     0   100 |
|    LUNA/BUSD |      1 |           2.03 |           2.03 |             3.053 |           0.31 |          1:45:00 |     1     0     0   100 |
|    LINK/BUSD |      1 |           2.03 |           2.03 |             3.050 |           0.31 |  3 days, 3:30:00 |     1     0     0   100 |
|    BAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     BCH/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     BTT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    BZRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     CTK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    DASH/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    DOCK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    DODO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     DOT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    EGLD/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   FORTH/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     GRT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    HARD/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    IOST/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     KNC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     LIT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    MANA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   MATIC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     MDX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    NANO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    NEAR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ONE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    POND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    REEF/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     RSR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    SAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    SHIB/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SOL/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SRM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   SUPER/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   SUSHI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SXP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TLM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TWT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     UNI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     WRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XRP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XTZ/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XVG/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XVS/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     YFI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ZEC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ZIL/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    PERP/BUSD |      3 |          -0.64 |          -1.92 |            -2.881 |          -0.29 |  2 days, 1:15:00 |     2     0     1  66.7 |
|     CRV/BUSD |      1 |          -4.56 |          -4.56 |            -6.846 |          -0.68 | 7 days, 18:45:00 |     0     0     1     0 |
|   1INCH/BUSD |      3 |          -1.73 |          -5.20 |            -7.805 |          -0.78 | 3 days, 11:05:00 |     2     0     1  66.7 |
|     MKR/BUSD |      1 |          -8.46 |          -8.46 |           -12.700 |          -1.27 | 7 days, 16:15:00 |     0     0     1     0 |
|   CREAM/BUSD |      3 |          -2.93 |          -8.79 |           -13.204 |          -1.32 | 4 days, 16:45:00 |     2     0     1  66.7 |
|     SFP/BUSD |      1 |         -12.12 |         -12.12 |           -18.192 |          -1.82 | 3 days, 22:30:00 |     0     0     1     0 |
|    AVAX/BUSD |      2 |          -9.06 |         -18.12 |           -27.202 |          -2.72 |   1 day, 1:22:00 |     1     0     1  50.0 |
|     ICP/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 | 6 days, 23:00:00 |     0     0     1     0 |
|    IOTX/BUSD |      4 |          -8.31 |         -33.25 |           -49.926 |          -4.99 |  1 day, 20:56:00 |     2     0     2  50.0 |
|        TOTAL |    105 |           2.33 |         244.90 |           367.714 |          36.77 |  1 day, 18:00:00 |    94     0    11  89.5 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |      94 |     94     0     0   100 |           4.22 |         396.29 |           595.034 |          66.05 |
|         force_sell |       6 |      0     0     6     0 |          -8.43 |         -50.6  |           -75.97  |          -8.43 |
|          stop_loss |       5 |      0     0     5     0 |         -20.16 |        -100.8  |          -151.35  |         -16.8  |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
| ALICE/BUSD |      1 |          -0.31 |          -0.31 |            -0.466 |          -0.05 |          6:00:00 |     0     0     1     0 |
|   CRV/BUSD |      1 |          -4.56 |          -4.56 |            -6.846 |          -0.68 | 7 days, 18:45:00 |     0     0     1     0 |
|   MKR/BUSD |      1 |          -8.46 |          -8.46 |           -12.700 |          -1.27 | 7 days, 16:15:00 |     0     0     1     0 |
| 1INCH/BUSD |      1 |         -10.88 |         -10.88 |           -16.339 |          -1.63 | 9 days, 23:15:00 |     0     0     1     0 |
|   SFP/BUSD |      1 |         -12.12 |         -12.12 |           -18.192 |          -1.82 | 3 days, 22:30:00 |     0     0     1     0 |
| CREAM/BUSD |      1 |         -14.27 |         -14.27 |           -21.428 |          -2.14 | 9 days, 12:45:00 |     0     0     1     0 |
|      TOTAL |      6 |          -8.43 |         -50.60 |           -75.970 |          -7.60 | 6 days, 12:35:00 |     0     0     6     0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-08-01 00:00:00 |
| Backtesting to         | 2021-09-01 00:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 105 / 3.39          |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1367.714 BUSD       |
| Absolute profit        | 367.714 BUSD        |
| Total profit %         | 36.77%              |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 15750.000 BUSD      |
|                        |                     |
| Best Pair              | ATA/BUSD 30.72%     |
| Worst Pair             | IOTX/BUSD -33.25%   |
| Best trade             | AUDIO/BUSD 16.06%   |
| Worst trade            | PERP/BUSD -20.16%   |
| Best day               | 61.836 BUSD         |
| Worst day              | -75.970 BUSD        |
| Days win/draw/lose     | 22 / 5 / 5          |
| Avg. Duration Winners  | 1 day, 8:45:00      |
| Avg. Duration Loser    | 5 days, 1:08:00     |
| Rejected Buy signals   | 290875              |
|                        |                     |
| Min balance            | 1007.211 BUSD       |
| Max balance            | 1473.954 BUSD       |
| Drawdown               | 70.76%              |
| Drawdown               | 106.240 BUSD        |
| Drawdown high          | 473.954 BUSD        |
| Drawdown low           | 367.714 BUSD        |
| Drawdown Start         | 2021-08-29 20:00:00 |
| Drawdown End           | 2021-09-01 00:00:00 |
| Market change          | 81.5%               |
================================================

Result for strategy Apollo11_3
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
| AUCTION/BUSD |      4 |           4.06 |          16.26 |            24.411 |           2.44 |  2 days, 0:30:00 |     4     0     0   100 |
|    DEXE/BUSD |      4 |           3.88 |          15.51 |            23.285 |           2.33 |          4:38:00 |     4     0     0   100 |
|     AXS/BUSD |      3 |           5.16 |          15.49 |            23.261 |           2.33 |   1 day, 6:40:00 |     3     0     0   100 |
|   1INCH/BUSD |      4 |           3.16 |          12.64 |            18.976 |           1.90 |          5:15:00 |     4     0     0   100 |
|    RUNE/BUSD |      3 |           3.80 |          11.40 |            17.120 |           1.71 |          9:25:00 |     3     0     0   100 |
|    ALGO/BUSD |      3 |           3.69 |          11.06 |            16.610 |           1.66 |         14:30:00 |     3     0     0   100 |
|     ANT/BUSD |      2 |           5.38 |          10.76 |            16.153 |           1.62 | 3 days, 14:45:00 |     2     0     0   100 |
|    CTSI/BUSD |      4 |           2.66 |          10.64 |            15.983 |           1.60 |   1 day, 0:56:00 |     4     0     0   100 |
|     EPS/BUSD |      3 |           3.32 |           9.96 |            14.953 |           1.50 |          6:30:00 |     3     0     0   100 |
|   FRONT/BUSD |      2 |           4.68 |           9.37 |            14.069 |           1.41 |         20:52:00 |     2     0     0   100 |
|    HARD/BUSD |      1 |           9.10 |           9.10 |            13.663 |           1.37 |  3 days, 7:00:00 |     1     0     0   100 |
|     FIO/BUSD |      3 |           2.83 |           8.48 |            12.736 |           1.27 |  2 days, 0:30:00 |     3     0     0   100 |
|    DEGO/BUSD |      2 |           4.15 |           8.30 |            12.467 |           1.25 |          3:08:00 |     2     0     0   100 |
|     PHA/BUSD |      2 |           4.05 |           8.10 |            12.160 |           1.22 | 2 days, 12:30:00 |     2     0     0   100 |
|   ALICE/BUSD |      3 |           2.63 |           7.88 |            11.836 |           1.18 |         22:35:00 |     3     0     0   100 |
|     BEL/BUSD |      1 |           7.75 |           7.75 |            11.630 |           1.16 |  2 days, 0:30:00 |     1     0     0   100 |
|   AERGO/BUSD |      4 |           1.76 |           7.05 |            10.579 |           1.06 |  1 day, 19:26:00 |     4     0     0   100 |
|    IOST/BUSD |      2 |           3.43 |           6.86 |            10.303 |           1.03 |         15:45:00 |     2     0     0   100 |
|     UFT/BUSD |      2 |           3.27 |           6.53 |             9.807 |           0.98 |   1 day, 9:00:00 |     2     0     0   100 |
|     ATA/BUSD |      3 |           1.98 |           5.94 |             8.914 |           0.89 |  2 days, 3:55:00 |     3     0     0   100 |
|    DATA/BUSD |      2 |           2.91 |           5.81 |             8.724 |           0.87 |  3 days, 8:52:00 |     2     0     0   100 |
|    POLS/BUSD |      2 |           2.88 |           5.77 |             8.662 |           0.87 |         10:45:00 |     2     0     0   100 |
|     FXS/BUSD |      2 |           2.82 |           5.64 |             8.468 |           0.85 |         12:22:00 |     2     0     0   100 |
|   AUDIO/BUSD |      2 |           2.44 |           4.88 |             7.331 |           0.73 |          5:22:00 |     2     0     0   100 |
|   ALPHA/BUSD |      1 |           4.85 |           4.85 |             7.286 |           0.73 |   1 day, 0:45:00 |     1     0     0   100 |
|     GTC/BUSD |      1 |           4.80 |           4.80 |             7.211 |           0.72 |          3:30:00 |     1     0     0   100 |
|   CREAM/BUSD |      2 |           2.39 |           4.78 |             7.182 |           0.72 | 2 days, 12:00:00 |     2     0     0   100 |
|     SOL/BUSD |      1 |           4.66 |           4.66 |             6.994 |           0.70 |         14:45:00 |     1     0     0   100 |
|     GRT/BUSD |      1 |           4.45 |           4.45 |             6.678 |           0.67 |          8:30:00 |     1     0     0   100 |
|    NEAR/BUSD |      1 |           4.12 |           4.12 |             6.181 |           0.62 |          7:30:00 |     1     0     0   100 |
|    BZRX/BUSD |      1 |           3.75 |           3.75 |             5.627 |           0.56 |          4:45:00 |     1     0     0   100 |
|    DOCK/BUSD |      1 |           3.73 |           3.73 |             5.607 |           0.56 |         22:15:00 |     1     0     0   100 |
|    DASH/BUSD |      1 |           3.34 |           3.34 |             5.018 |           0.50 |          6:00:00 |     1     0     0   100 |
|    COMP/BUSD |      1 |           3.33 |           3.33 |             4.996 |           0.50 |          4:15:00 |     1     0     0   100 |
|     BTT/BUSD |      1 |           3.31 |           3.31 |             4.966 |           0.50 |   1 day, 2:00:00 |     1     0     0   100 |
|    DODO/BUSD |      1 |           3.04 |           3.04 |             4.569 |           0.46 |          5:45:00 |     1     0     0   100 |
|    ATOM/BUSD |      1 |           2.89 |           2.89 |             4.332 |           0.43 |         19:30:00 |     1     0     0   100 |
|    LINA/BUSD |      1 |           2.86 |           2.86 |             4.298 |           0.43 |          5:00:00 |     1     0     0   100 |
|   OCEAN/BUSD |      1 |           2.83 |           2.83 |             4.255 |           0.43 |          8:00:00 |     1     0     0   100 |
|     ENJ/BUSD |      1 |           2.70 |           2.70 |             4.047 |           0.40 |  2 days, 4:30:00 |     1     0     0   100 |
|   THETA/BUSD |      1 |           2.55 |           2.55 |             3.826 |           0.38 | 2 days, 16:15:00 |     1     0     0   100 |
|    KEEP/BUSD |      1 |           2.44 |           2.44 |             3.670 |           0.37 |          1:15:00 |     1     0     0   100 |
|    SHIB/BUSD |      1 |           2.43 |           2.43 |             3.648 |           0.36 |          3:15:00 |     1     0     0   100 |
|     DGB/BUSD |      1 |           2.41 |           2.41 |             3.622 |           0.36 |  1 day, 17:15:00 |     1     0     0   100 |
|    POND/BUSD |      1 |           2.36 |           2.36 |             3.539 |           0.35 |          3:00:00 |     1     0     0   100 |
|     INJ/BUSD |      1 |           2.34 |           2.34 |             3.508 |           0.35 | 2 days, 18:45:00 |     1     0     0   100 |
|     TKO/BUSD |      1 |           2.12 |           2.12 |             3.190 |           0.32 | 4 days, 20:30:00 |     1     0     0   100 |
|     XVS/BUSD |      1 |           2.09 |           2.09 |             3.136 |           0.31 |  2 days, 3:00:00 |     1     0     0   100 |
|    COTI/BUSD |      1 |           2.08 |           2.08 |             3.131 |           0.31 |  1 day, 11:30:00 |     1     0     0   100 |
|    AVAX/BUSD |      1 |           2.04 |           2.04 |             3.068 |           0.31 |          5:30:00 |     1     0     0   100 |
|    LUNA/BUSD |      1 |           2.03 |           2.03 |             3.053 |           0.31 |          1:45:00 |     1     0     0   100 |
|    LINK/BUSD |      1 |           2.03 |           2.03 |             3.050 |           0.31 |  3 days, 3:30:00 |     1     0     0   100 |
|     MIR/BUSD |      1 |           2.00 |           2.00 |             3.003 |           0.30 |          1:45:00 |     1     0     0   100 |
|    IDEX/BUSD |      1 |           1.73 |           1.73 |             2.592 |           0.26 |  4 days, 0:15:00 |     1     0     0   100 |
|     CVP/BUSD |      2 |           0.58 |           1.16 |             1.738 |           0.17 | 4 days, 15:38:00 |     2     0     0   100 |
|      IQ/BUSD |      1 |           1.01 |           1.01 |             1.520 |           0.15 |  5 days, 9:00:00 |     1     0     0   100 |
|    PROM/BUSD |      3 |           0.31 |           0.93 |             1.401 |           0.14 |         12:05:00 |     2     0     1  66.7 |
|     SKL/BUSD |      1 |           0.49 |           0.49 |             0.740 |           0.07 | 3 days, 23:15:00 |     1     0     0   100 |
|    AAVE/BUSD |      2 |           0.17 |           0.34 |             0.506 |           0.05 | 6 days, 14:52:00 |     1     0     1  50.0 |
|      AR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     AVA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    BAKE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    BAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     BCH/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     CRV/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     CTK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     DOT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    EGLD/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   FORTH/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FTM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     HOT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     KNC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     KSM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     LIT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     LTC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    MANA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   MATIC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     MDX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     MKR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    NANO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ONE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    REEF/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     RSR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    SAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SFP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SNX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SRM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    STMX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   SUSHI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SXP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TLM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TVK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TWT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     UNI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   WAVES/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     WRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XRP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XTZ/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XVG/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     YFI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ZEC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ZIL/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FIL/BUSD |      1 |          -0.67 |          -0.67 |            -1.007 |          -0.10 |  6 days, 7:15:00 |     0     0     1     0 |
|    PERP/BUSD |      3 |          -0.64 |          -1.92 |            -2.881 |          -0.29 |  2 days, 1:15:00 |     2     0     1  66.7 |
|   SUPER/BUSD |      1 |          -2.01 |          -2.01 |            -3.024 |          -0.30 |          9:15:00 |     0     0     1     0 |
|     ICP/BUSD |      2 |          -7.73 |         -15.46 |           -23.207 |          -2.32 |  3 days, 5:08:00 |     1     0     1  50.0 |
|    DOGE/BUSD |      1 |         -15.89 |         -15.89 |           -23.861 |          -2.39 | 11 days, 7:30:00 |     0     0     1     0 |
|    IOTX/BUSD |      3 |          -5.47 |         -16.41 |           -24.636 |          -2.46 |  1 day, 21:15:00 |     2     0     1  66.7 |
|        TOTAL |    114 |           2.31 |         262.86 |           394.678 |          39.47 |  1 day, 14:43:00 |   106     0     8  93.0 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |     105 |    105     0     0   100 |           3.32 |         348.88 |           523.851 |          58.15 |
|         force_sell |       6 |      1     0     5  16.7 |          -4.26 |         -25.55 |           -38.363 |          -4.26 |
|          stop_loss |       3 |      0     0     3     0 |         -20.16 |         -60.48 |           -90.81  |         -10.08 |
========================================================= LEFT OPEN TRADES REPORT ==========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |      Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+-------------------+-------------------------|
| AERGO/BUSD |      1 |           0.44 |           0.44 |             0.655 |           0.07 |          13:45:00 |     1     0     0   100 |
|   FIL/BUSD |      1 |          -0.67 |          -0.67 |            -1.007 |          -0.10 |   6 days, 7:15:00 |     0     0     1     0 |
| SUPER/BUSD |      1 |          -2.01 |          -2.01 |            -3.024 |          -0.30 |           9:15:00 |     0     0     1     0 |
|  AAVE/BUSD |      1 |          -2.88 |          -2.88 |            -4.320 |          -0.43 | 10 days, 23:15:00 |     0     0     1     0 |
|  PROM/BUSD |      1 |          -4.53 |          -4.53 |            -6.805 |          -0.68 |    1 day, 2:00:00 |     0     0     1     0 |
|  DOGE/BUSD |      1 |         -15.89 |         -15.89 |           -23.861 |          -2.39 |  11 days, 7:30:00 |     0     0     1     0 |
|      TOTAL |      6 |          -4.26 |         -25.55 |           -38.363 |          -3.84 |   5 days, 2:30:00 |     1     0     5  16.7 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-08-01 00:00:00 |
| Backtesting to         | 2021-09-01 00:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 114 / 3.68          |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1394.678 BUSD       |
| Absolute profit        | 394.678 BUSD        |
| Total profit %         | 39.47%              |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 17100.000 BUSD      |
|                        |                     |
| Best Pair              | AUCTION/BUSD 16.26% |
| Worst Pair             | IOTX/BUSD -16.41%   |
| Best trade             | PERP/BUSD 14.3%     |
| Worst trade            | PERP/BUSD -20.16%   |
| Best day               | 51.176 BUSD         |
| Worst day              | -38.363 BUSD        |
| Days win/draw/lose     | 26 / 3 / 3          |
| Avg. Duration Winners  | 1 day, 8:10:00      |
| Avg. Duration Loser    | 5 days, 5:28:00     |
| Rejected Buy signals   | 292195              |
|                        |                     |
| Min balance            | 1007.211 BUSD       |
| Max balance            | 1433.041 BUSD       |
| Drawdown               | 40.32%              |
| Drawdown               | 60.540 BUSD         |
| Drawdown high          | 294.015 BUSD        |
| Drawdown low           | 233.475 BUSD        |
| Drawdown Start         | 2021-08-17 18:30:00 |
| Drawdown End           | 2021-08-17 20:30:00 |
| Market change          | 81.5%               |
================================================

2021-08-01 00:00:00 -> 2021-09-01 00:00:00 | Max open trades : 6
======================================================================== STRATEGY SUMMARY =======================================================================
|   Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |    Avg Duration |   Win  Draw  Loss  Win% |             Drawdown |
|------------+--------+----------------+----------------+-------------------+----------------+-----------------+-------------------------+----------------------|
|   Apollo11 |    105 |           2.33 |         244.90 |           367.714 |          36.77 | 1 day, 18:00:00 |    94     0    11  89.5 | 106.240 BUSD  70.76% |
| Apollo11_3 |    114 |           2.31 |         262.86 |           394.678 |          39.47 | 1 day, 14:43:00 |   106     0     8  93.0 |  60.540 BUSD  40.32% |
=================================================================================================================================================================
```
# September
```
Result for strategy Apollo11
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|   CREAM/BUSD |      4 |           9.93 |          39.72 |            59.638 |           5.96 | 2 days, 11:11:00 |     4     0     0   100 |
|     LTC/BUSD |      1 |          21.12 |          21.12 |            31.710 |           3.17 |  5 days, 9:30:00 |     1     0     0   100 |
|    DOCK/BUSD |      4 |           3.76 |          15.03 |            22.568 |           2.26 |          4:49:00 |     4     0     0   100 |
|    DEXE/BUSD |      5 |           2.91 |          14.55 |            21.846 |           2.18 |  1 day, 10:42:00 |     5     0     0   100 |
|     EPS/BUSD |      4 |           3.04 |          12.16 |            18.256 |           1.83 |         11:26:00 |     4     0     0   100 |
|   SUPER/BUSD |      4 |           2.99 |          11.96 |            17.965 |           1.80 |  2 days, 0:45:00 |     4     0     0   100 |
|   AERGO/BUSD |      3 |           3.80 |          11.39 |            17.099 |           1.71 | 2 days, 19:55:00 |     3     0     0   100 |
|    MANA/BUSD |      3 |           2.63 |           7.89 |            11.841 |           1.18 |   1 day, 4:35:00 |     3     0     0   100 |
|    HARD/BUSD |      3 |           2.43 |           7.30 |            10.960 |           1.10 |         12:00:00 |     3     0     0   100 |
|    LINA/BUSD |      2 |           3.35 |           6.69 |            10.047 |           1.00 |         19:38:00 |     2     0     0   100 |
|     FIL/BUSD |      2 |           3.23 |           6.47 |             9.710 |           0.97 |          7:15:00 |     2     0     0   100 |
|    ALGO/BUSD |      2 |           2.98 |           5.96 |             8.944 |           0.89 |          1:45:00 |     2     0     0   100 |
|    SHIB/BUSD |      1 |           5.83 |           5.83 |             8.750 |           0.88 |  1 day, 12:30:00 |     1     0     0   100 |
|    ATOM/BUSD |      2 |           2.80 |           5.61 |             8.418 |           0.84 |          7:15:00 |     2     0     0   100 |
|   FORTH/BUSD |      2 |           2.77 |           5.54 |             8.313 |           0.83 |          2:22:00 |     2     0     0   100 |
|     ATA/BUSD |      2 |           2.77 |           5.53 |             8.307 |           0.83 |          4:08:00 |     2     0     0   100 |
|     KSM/BUSD |      2 |           2.59 |           5.17 |             7.768 |           0.78 |          5:52:00 |     2     0     0   100 |
|    CTSI/BUSD |      1 |           4.91 |           4.91 |             7.379 |           0.74 |         14:00:00 |     1     0     0   100 |
|    PERP/BUSD |      1 |           4.74 |           4.74 |             7.111 |           0.71 |          2:00:00 |     1     0     0   100 |
|     ANT/BUSD |      2 |           2.34 |           4.67 |             7.019 |           0.70 | 2 days, 10:00:00 |     2     0     0   100 |
|     ZIL/BUSD |      1 |           4.60 |           4.60 |             6.901 |           0.69 |          2:30:00 |     1     0     0   100 |
|     SKL/BUSD |      1 |           4.58 |           4.58 |             6.871 |           0.69 | 2 days, 18:15:00 |     1     0     0   100 |
|     FXS/BUSD |      1 |           4.33 |           4.33 |             6.505 |           0.65 | 8 days, 22:30:00 |     1     0     0   100 |
|     INJ/BUSD |      1 |           4.24 |           4.24 |             6.372 |           0.64 |         10:30:00 |     1     0     0   100 |
|     CRV/BUSD |      1 |           4.16 |           4.16 |             6.252 |           0.63 |          1:30:00 |     1     0     0   100 |
|    AVAX/BUSD |      1 |           4.10 |           4.10 |             6.150 |           0.61 |          5:00:00 |     1     0     0   100 |
|     GRT/BUSD |      1 |           3.89 |           3.89 |             5.848 |           0.58 |          2:30:00 |     1     0     0   100 |
|    LUNA/BUSD |      1 |           3.30 |           3.30 |             4.950 |           0.49 |          6:45:00 |     1     0     0   100 |
|    IOST/BUSD |      1 |           2.99 |           2.99 |             4.490 |           0.45 |         23:00:00 |     1     0     0   100 |
|    POND/BUSD |      1 |           2.87 |           2.87 |             4.312 |           0.43 |          2:30:00 |     1     0     0   100 |
|    DEGO/BUSD |      1 |           2.76 |           2.76 |             4.146 |           0.41 |  2 days, 1:00:00 |     1     0     0   100 |
|     SXP/BUSD |      1 |           2.76 |           2.76 |             4.141 |           0.41 |          1:00:00 |     1     0     0   100 |
|   AUDIO/BUSD |      1 |           2.65 |           2.65 |             3.979 |           0.40 |         20:45:00 |     1     0     0   100 |
|     DOT/BUSD |      1 |           2.59 |           2.59 |             3.889 |           0.39 |         20:45:00 |     1     0     0   100 |
|     SRM/BUSD |      1 |           2.58 |           2.58 |             3.876 |           0.39 |         18:30:00 |     1     0     0   100 |
|     LIT/BUSD |      1 |           2.56 |           2.56 |             3.847 |           0.38 |          1:15:00 |     1     0     0   100 |
|    DODO/BUSD |      1 |           2.42 |           2.42 |             3.630 |           0.36 |  1 day, 15:00:00 |     1     0     0   100 |
|    DATA/BUSD |      1 |           2.41 |           2.41 |             3.614 |           0.36 |         12:45:00 |     1     0     0   100 |
|     SNX/BUSD |      1 |           2.39 |           2.39 |             3.595 |           0.36 |          7:45:00 |     1     0     0   100 |
|     TVK/BUSD |      1 |           2.28 |           2.28 |             3.425 |           0.34 |          6:00:00 |     1     0     0   100 |
|    RUNE/BUSD |      1 |           2.23 |           2.23 |             3.345 |           0.33 |          8:15:00 |     1     0     0   100 |
|    EGLD/BUSD |      1 |           2.18 |           2.18 |             3.271 |           0.33 |  1 day, 10:45:00 |     1     0     0   100 |
|     TKO/BUSD |      1 |           2.13 |           2.13 |             3.192 |           0.32 |          5:45:00 |     1     0     0   100 |
|     HOT/BUSD |      1 |           2.04 |           2.04 |             3.058 |           0.31 |          0:15:00 |     1     0     0   100 |
|     XVS/BUSD |      1 |           2.01 |           2.01 |             3.021 |           0.30 |          7:00:00 |     1     0     0   100 |
|   FRONT/BUSD |      1 |           1.05 |           1.05 |             1.577 |           0.16 |   1 day, 4:45:00 |     1     0     0   100 |
|     DGB/BUSD |      2 |           0.44 |           0.88 |             1.317 |           0.13 |  1 day, 21:22:00 |     1     0     1  50.0 |
|   ALPHA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     AVA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     AXS/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    BAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     BEL/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     BTT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    BZRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     CTK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    DOGE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ENJ/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FIO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FTM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ICP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    IDEX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    IOTX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|      IQ/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     KNC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    LINK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   MATIC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     MDX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     MKR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    NANO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    NEAR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   OCEAN/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ONE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     PHA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    POLS/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    PROM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    REEF/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     RSR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    SAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SFP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SOL/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    STMX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   SUSHI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TLM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TWT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     UFT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   WAVES/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     WRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XRP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XVG/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     YFI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ZEC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   ALICE/BUSD |      4 |          -1.99 |          -7.96 |           -11.958 |          -1.20 |   1 day, 3:08:00 |     3     0     1  75.0 |
|    KEEP/BUSD |      1 |          -7.98 |          -7.98 |           -11.977 |          -1.20 | 7 days, 15:30:00 |     0     0     1     0 |
|     MIR/BUSD |      1 |          -9.62 |          -9.62 |           -14.449 |          -1.44 | 9 days, 12:30:00 |     0     0     1     0 |
|      AR/BUSD |      4 |          -2.55 |         -10.18 |           -15.290 |          -1.53 |          9:15:00 |     3     0     1  75.0 |
|    AAVE/BUSD |      3 |          -3.51 |         -10.54 |           -15.821 |          -1.58 | 4 days, 14:10:00 |     2     0     1  66.7 |
| AUCTION/BUSD |      3 |          -4.29 |         -12.88 |           -19.334 |          -1.93 |         20:55:00 |     2     0     1  66.7 |
|    COMP/BUSD |      3 |          -4.39 |         -13.16 |           -19.754 |          -1.98 | 3 days, 20:15:00 |     2     0     1  66.7 |
|    COTI/BUSD |      2 |          -7.11 |         -14.22 |           -21.345 |          -2.13 |   1 day, 4:52:00 |     1     0     1  50.0 |
|     CVP/BUSD |      2 |          -8.61 |         -17.21 |           -25.846 |          -2.58 | 4 days, 13:52:00 |     1     0     1  50.0 |
|     BCH/BUSD |      3 |          -5.88 |         -17.63 |           -26.465 |          -2.65 |  3 days, 6:55:00 |     1     0     2  33.3 |
|     UNI/BUSD |      2 |          -8.97 |         -17.94 |           -26.942 |          -2.69 | 3 days, 10:52:00 |     1     0     1  50.0 |
|    BAKE/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 | 4 days, 17:30:00 |     0     0     1     0 |
|     GTC/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |   1 day, 7:15:00 |     0     0     1     0 |
|     XTZ/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |  2 days, 7:00:00 |     0     0     1     0 |
|    DASH/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |   1 day, 2:00:00 |     0     0     1     0 |
|   1INCH/BUSD |      3 |         -12.69 |         -38.06 |           -57.145 |          -5.71 |         18:45:00 |     1     0     2  33.3 |
|        TOTAL |    113 |           0.19 |          21.19 |            31.814 |           3.18 |  1 day, 13:46:00 |    94     0    19  83.2 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |      93 |     93     0     0   100 |           3.69 |         343.34 |           515.525 |          57.22 |
|          stop_loss |      15 |      0     0    15     0 |         -20.16 |        -302.4  |          -454.05  |         -50.4  |
|         force_sell |       5 |      1     0     4  20.0 |          -3.95 |         -19.75 |           -29.661 |          -3.29 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
| FRONT/BUSD |      1 |           1.05 |           1.05 |             1.577 |           0.16 |   1 day, 4:45:00 |     1     0     0   100 |
|   BCH/BUSD |      1 |          -0.08 |          -0.08 |            -0.121 |          -0.01 | 3 days, 14:00:00 |     0     0     1     0 |
|   DGB/BUSD |      1 |          -3.12 |          -3.12 |            -4.691 |          -0.47 | 3 days, 13:30:00 |     0     0     1     0 |
|  KEEP/BUSD |      1 |          -7.98 |          -7.98 |           -11.977 |          -1.20 | 7 days, 15:30:00 |     0     0     1     0 |
|   MIR/BUSD |      1 |          -9.62 |          -9.62 |           -14.449 |          -1.44 | 9 days, 12:30:00 |     0     0     1     0 |
|      TOTAL |      5 |          -3.95 |         -19.75 |           -29.661 |          -2.97 |  5 days, 2:27:00 |     1     0     4  20.0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-09-01 00:00:00 |
| Backtesting to         | 2021-10-01 00:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 113 / 3.77          |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1031.814 BUSD       |
| Absolute profit        | 31.814 BUSD         |
| Total profit %         | 3.18%               |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 16950.000 BUSD      |
|                        |                     |
| Best Pair              | CREAM/BUSD 39.72%   |
| Worst Pair             | 1INCH/BUSD -38.06%  |
| Best trade             | LTC/BUSD 21.12%     |
| Worst trade            | 1INCH/BUSD -20.16%  |
| Best day               | 45.247 BUSD         |
| Worst day              | -109.792 BUSD       |
| Days win/draw/lose     | 18 / 7 / 6          |
| Avg. Duration Winners  | 1 day, 4:17:00      |
| Avg. Duration Loser    | 3 days, 12:37:00    |
| Rejected Buy signals   | 283908              |
|                        |                     |
| Min balance            | 1004.008 BUSD       |
| Max balance            | 1215.506 BUSD       |
| Drawdown               | 124.02%             |
| Drawdown               | 186.223 BUSD        |
| Drawdown high          | 215.506 BUSD        |
| Drawdown low           | 29.283 BUSD         |
| Drawdown Start         | 2021-09-18 19:45:00 |
| Drawdown End           | 2021-09-26 07:30:00 |
| Market change          | -3.19%              |
================================================

Result for strategy Apollo11_3
============================================================= BACKTESTING REPORT ============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
|   CREAM/BUSD |      5 |           8.60 |          43.00 |            64.570 |           6.46 |  1 day, 23:36:00 |     5     0     0   100 |
|     LTC/BUSD |      1 |          21.12 |          21.12 |            31.710 |           3.17 |  5 days, 9:30:00 |     1     0     0   100 |
|    DOCK/BUSD |      4 |           3.76 |          15.03 |            22.568 |           2.26 |          4:49:00 |     4     0     0   100 |
|     EPS/BUSD |      4 |           3.04 |          12.16 |            18.256 |           1.83 |         11:26:00 |     4     0     0   100 |
|   SUPER/BUSD |      4 |           2.99 |          11.96 |            17.965 |           1.80 |  2 days, 0:45:00 |     4     0     0   100 |
|    DEXE/BUSD |      4 |           2.72 |          10.90 |            16.366 |           1.64 |  1 day, 17:11:00 |     4     0     0   100 |
|    AAVE/BUSD |      3 |           3.55 |          10.65 |            15.985 |           1.60 |  4 days, 0:05:00 |     3     0     0   100 |
|     TKO/BUSD |      2 |           4.31 |           8.63 |            12.951 |           1.30 |         13:30:00 |     2     0     0   100 |
|     ATA/BUSD |      3 |           2.54 |           7.62 |            11.435 |           1.14 |          3:20:00 |     3     0     0   100 |
|     GRT/BUSD |      2 |           3.40 |           6.80 |            10.207 |           1.02 |         16:52:00 |     2     0     0   100 |
|    LINA/BUSD |      2 |           3.35 |           6.69 |            10.047 |           1.00 |         19:38:00 |     2     0     0   100 |
|     FIL/BUSD |      2 |           3.23 |           6.47 |             9.710 |           0.97 |          7:15:00 |     2     0     0   100 |
|    COMP/BUSD |      2 |           3.14 |           6.27 |             9.419 |           0.94 | 3 days, 16:15:00 |     2     0     0   100 |
|    SHIB/BUSD |      1 |           5.83 |           5.83 |             8.750 |           0.88 |  1 day, 12:30:00 |     1     0     0   100 |
|    ATOM/BUSD |      2 |           2.80 |           5.61 |             8.418 |           0.84 |          7:15:00 |     2     0     0   100 |
|   FORTH/BUSD |      2 |           2.77 |           5.54 |             8.313 |           0.83 |          2:22:00 |     2     0     0   100 |
|   AERGO/BUSD |      3 |           1.73 |           5.18 |             7.773 |           0.78 |         16:15:00 |     3     0     0   100 |
|     KSM/BUSD |      2 |           2.59 |           5.17 |             7.768 |           0.78 |          5:52:00 |     2     0     0   100 |
|    MANA/BUSD |      2 |           2.56 |           5.11 |             7.674 |           0.77 |         14:00:00 |     2     0     0   100 |
|    CTSI/BUSD |      1 |           4.91 |           4.91 |             7.379 |           0.74 |         14:00:00 |     1     0     0   100 |
|    PERP/BUSD |      1 |           4.74 |           4.74 |             7.111 |           0.71 |          2:00:00 |     1     0     0   100 |
|     ZIL/BUSD |      1 |           4.60 |           4.60 |             6.901 |           0.69 |          2:30:00 |     1     0     0   100 |
|     SKL/BUSD |      1 |           4.58 |           4.58 |             6.871 |           0.69 | 2 days, 18:15:00 |     1     0     0   100 |
|     SNX/BUSD |      2 |           2.19 |           4.38 |             6.579 |           0.66 |          9:30:00 |     2     0     0   100 |
|     FXS/BUSD |      1 |           4.33 |           4.33 |             6.505 |           0.65 | 8 days, 22:30:00 |     1     0     0   100 |
|    HARD/BUSD |      2 |           2.14 |           4.28 |             6.421 |           0.64 |         14:38:00 |     2     0     0   100 |
|     INJ/BUSD |      1 |           4.24 |           4.24 |             6.372 |           0.64 |         10:30:00 |     1     0     0   100 |
|     CRV/BUSD |      1 |           4.16 |           4.16 |             6.252 |           0.63 |          1:30:00 |     1     0     0   100 |
|    AVAX/BUSD |      1 |           4.10 |           4.10 |             6.150 |           0.61 |          5:00:00 |     1     0     0   100 |
|    LUNA/BUSD |      1 |           3.30 |           3.30 |             4.950 |           0.49 |          6:45:00 |     1     0     0   100 |
|    IOST/BUSD |      1 |           2.99 |           2.99 |             4.490 |           0.45 |         23:00:00 |     1     0     0   100 |
|    KEEP/BUSD |      1 |           2.90 |           2.90 |             4.357 |           0.44 |          2:30:00 |     1     0     0   100 |
|    POND/BUSD |      1 |           2.87 |           2.87 |             4.312 |           0.43 |          2:30:00 |     1     0     0   100 |
|    DEGO/BUSD |      1 |           2.76 |           2.76 |             4.146 |           0.41 |  2 days, 1:00:00 |     1     0     0   100 |
|     SXP/BUSD |      1 |           2.76 |           2.76 |             4.141 |           0.41 |          1:00:00 |     1     0     0   100 |
|   AUDIO/BUSD |      1 |           2.65 |           2.65 |             3.979 |           0.40 |         20:45:00 |     1     0     0   100 |
|     DOT/BUSD |      1 |           2.59 |           2.59 |             3.889 |           0.39 |         20:45:00 |     1     0     0   100 |
|     SRM/BUSD |      1 |           2.58 |           2.58 |             3.876 |           0.39 |         18:30:00 |     1     0     0   100 |
|     LIT/BUSD |      1 |           2.56 |           2.56 |             3.847 |           0.38 |          1:15:00 |     1     0     0   100 |
|    DODO/BUSD |      1 |           2.42 |           2.42 |             3.630 |           0.36 |  1 day, 15:00:00 |     1     0     0   100 |
|    DATA/BUSD |      1 |           2.41 |           2.41 |             3.614 |           0.36 |         12:45:00 |     1     0     0   100 |
|     TVK/BUSD |      1 |           2.28 |           2.28 |             3.425 |           0.34 |          6:00:00 |     1     0     0   100 |
|    RUNE/BUSD |      1 |           2.23 |           2.23 |             3.345 |           0.33 |          8:15:00 |     1     0     0   100 |
|     HOT/BUSD |      1 |           2.04 |           2.04 |             3.058 |           0.31 |          0:15:00 |     1     0     0   100 |
|     XVS/BUSD |      1 |           2.01 |           2.01 |             3.021 |           0.30 |          7:00:00 |     1     0     0   100 |
|    EGLD/BUSD |      1 |           1.95 |           1.95 |             2.928 |           0.29 |  1 day, 10:00:00 |     1     0     0   100 |
|     ANT/BUSD |      1 |           1.87 |           1.87 |             2.813 |           0.28 |  1 day, 20:30:00 |     1     0     0   100 |
|   FRONT/BUSD |      1 |           1.05 |           1.05 |             1.577 |           0.16 |   1 day, 4:45:00 |     1     0     0   100 |
|     DGB/BUSD |      2 |           0.44 |           0.88 |             1.317 |           0.13 |  1 day, 21:22:00 |     1     0     1  50.0 |
|   ALPHA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     AVA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     AXS/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    BAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     BTT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    BZRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     CTK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    DOGE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ENJ/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FIO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     FTM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ICP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    IDEX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    IOTX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|      IQ/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     KNC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    LINK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   MATIC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     MDX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     MKR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    NANO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    NEAR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   OCEAN/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ONE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     PHA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    POLS/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    PROM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    REEF/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     RSR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    SAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SFP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     SOL/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    STMX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   SUSHI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TLM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     TWT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     UFT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|   WAVES/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     WRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XRP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     XVG/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     YFI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|     ZEC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |             0:00 |     0     0     0     0 |
|    ALGO/BUSD |      3 |          -1.13 |          -3.40 |            -5.104 |          -0.51 |  1 day, 14:40:00 |     2     0     1  66.7 |
|    COTI/BUSD |      3 |          -1.56 |          -4.68 |            -7.034 |          -0.70 |         21:15:00 |     2     0     1  66.7 |
|   ALICE/BUSD |      4 |          -1.99 |          -7.96 |           -11.958 |          -1.20 |   1 day, 3:08:00 |     3     0     1  75.0 |
|     MIR/BUSD |      1 |          -9.62 |          -9.62 |           -14.449 |          -1.44 | 9 days, 12:30:00 |     0     0     1     0 |
|      AR/BUSD |      3 |          -4.06 |         -12.19 |           -18.307 |          -1.83 |         12:10:00 |     2     0     1  66.7 |
|     CVP/BUSD |      2 |          -8.61 |         -17.21 |           -25.846 |          -2.58 | 4 days, 13:52:00 |     1     0     1  50.0 |
|     BCH/BUSD |      3 |          -5.88 |         -17.63 |           -26.465 |          -2.65 |  3 days, 6:55:00 |     1     0     2  33.3 |
|     UNI/BUSD |      2 |          -8.97 |         -17.94 |           -26.942 |          -2.69 | 3 days, 10:52:00 |     1     0     1  50.0 |
|     GTC/BUSD |      2 |          -9.77 |         -19.55 |           -29.350 |          -2.94 | 3 days, 14:22:00 |     1     0     1  50.0 |
|    BAKE/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 | 4 days, 17:30:00 |     0     0     1     0 |
|     BEL/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |  3 days, 2:15:00 |     0     0     1     0 |
|    DASH/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |   1 day, 2:00:00 |     0     0     1     0 |
| AUCTION/BUSD |      5 |          -6.06 |         -30.29 |           -45.481 |          -4.55 |  1 day, 12:12:00 |     3     0     2  60.0 |
|   1INCH/BUSD |      4 |          -8.90 |         -35.61 |           -53.462 |          -5.35 |         17:04:00 |     2     0     2  50.0 |
|     XTZ/BUSD |      2 |         -20.16 |         -40.32 |           -60.540 |          -6.05 |  3 days, 1:38:00 |     0     0     2     0 |
|        TOTAL |    120 |           0.12 |          14.24 |            21.389 |           2.14 |  1 day, 11:33:00 |   100     0    20  83.3 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |      99 |     99     0     0   100 |           3.63 |         359.71 |           540.109 |          59.95 |
|          stop_loss |      16 |      0     0    16     0 |         -20.16 |        -322.56 |          -484.32  |         -53.76 |
|         force_sell |       5 |      1     0     4  20.0 |          -4.58 |         -22.91 |           -34.401 |          -3.82 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
| FRONT/BUSD |      1 |           1.05 |           1.05 |             1.577 |           0.16 |   1 day, 4:45:00 |     1     0     0   100 |
|   BCH/BUSD |      1 |          -0.08 |          -0.08 |            -0.121 |          -0.01 | 3 days, 14:00:00 |     0     0     1     0 |
|   DGB/BUSD |      1 |          -3.12 |          -3.12 |            -4.691 |          -0.47 | 3 days, 13:30:00 |     0     0     1     0 |
|   MIR/BUSD |      1 |          -9.62 |          -9.62 |           -14.449 |          -1.44 | 9 days, 12:30:00 |     0     0     1     0 |
|  ALGO/BUSD |      1 |         -11.13 |         -11.13 |           -16.716 |          -1.67 | 3 days, 21:15:00 |     0     0     1     0 |
|      TOTAL |      5 |          -4.58 |         -22.91 |           -34.401 |          -3.44 |  4 days, 8:24:00 |     1     0     4  20.0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-09-01 00:00:00 |
| Backtesting to         | 2021-10-01 00:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 120 / 4.0           |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1021.389 BUSD       |
| Absolute profit        | 21.389 BUSD         |
| Total profit %         | 2.14%               |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 18000.000 BUSD      |
|                        |                     |
| Best Pair              | CREAM/BUSD 43.0%    |
| Worst Pair             | XTZ/BUSD -40.32%    |
| Best trade             | LTC/BUSD 21.12%     |
| Worst trade            | 1INCH/BUSD -20.16%  |
| Best day               | 45.247 BUSD         |
| Worst day              | -109.792 BUSD       |
| Days win/draw/lose     | 22 / 2 / 7          |
| Avg. Duration Winners  | 1 day, 2:32:00      |
| Avg. Duration Loser    | 3 days, 8:40:00     |
| Rejected Buy signals   | 284013              |
|                        |                     |
| Min balance            | 1004.008 BUSD       |
| Max balance            | 1220.010 BUSD       |
| Drawdown               | 136.72%             |
| Drawdown               | 205.290 BUSD        |
| Drawdown high          | 220.010 BUSD        |
| Drawdown low           | 14.720 BUSD         |
| Drawdown Start         | 2021-09-18 19:45:00 |
| Drawdown End           | 2021-09-26 07:30:00 |
| Market change          | -3.19%              |
================================================

2021-09-01 00:00:00 -> 2021-10-01 00:00:00 | Max open trades : 6
======================================================================== STRATEGY SUMMARY ========================================================================
|   Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |    Avg Duration |   Win  Draw  Loss  Win% |              Drawdown |
|------------+--------+----------------+----------------+-------------------+----------------+-----------------+-------------------------+-----------------------|
|   Apollo11 |    113 |           0.19 |          21.19 |            31.814 |           3.18 | 1 day, 13:46:00 |    94     0    19  83.2 | 186.223 BUSD  124.02% |
| Apollo11_3 |    120 |           0.12 |          14.24 |            21.389 |           2.14 | 1 day, 11:33:00 |   100     0    20  83.3 | 205.290 BUSD  136.72% |
==================================================================================================================================================================
```
# August and September
```
Result for strategy Apollo11
============================================================= BACKTESTING REPORT =============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |      Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+-------------------+-------------------------|
|     ATA/BUSD |      6 |           6.04 |          36.25 |            54.430 |           5.44 |          11:15:00 |     6     0     0   100 |
| AUCTION/BUSD |      7 |           3.78 |          26.49 |            39.770 |           3.98 |          14:34:00 |     7     0     0   100 |
|     LTC/BUSD |      2 |          11.64 |          23.29 |            34.965 |           3.50 |   6 days, 0:30:00 |     2     0     0   100 |
|     AXS/BUSD |      4 |           4.66 |          18.64 |            27.994 |           2.80 |          19:19:00 |     4     0     0   100 |
|     FXS/BUSD |      3 |           6.18 |          18.54 |            27.842 |           2.78 |  2 days, 14:15:00 |     3     0     0   100 |
|   AUDIO/BUSD |      2 |           9.22 |          18.44 |            27.688 |           2.77 |           7:45:00 |     2     0     0   100 |
|    DEXE/BUSD |      6 |           2.82 |          16.93 |            25.417 |           2.54 |   1 day, 10:15:00 |     6     0     0   100 |
|   ALPHA/BUSD |      3 |           5.41 |          16.24 |            24.384 |           2.44 |    1 day, 2:55:00 |     3     0     0   100 |
|     FIO/BUSD |      1 |          15.83 |          15.83 |            23.770 |           2.38 |  4 days, 22:00:00 |     1     0     0   100 |
|    DATA/BUSD |      4 |           3.88 |          15.53 |            23.319 |           2.33 |          14:26:00 |     4     0     0   100 |
|    DOCK/BUSD |      4 |           3.87 |          15.48 |            23.251 |           2.33 |          10:41:00 |     4     0     0   100 |
|    ALGO/BUSD |      3 |           4.00 |          12.01 |            18.034 |           1.80 |           6:05:00 |     3     0     0   100 |
|     EPS/BUSD |      4 |           2.93 |          11.73 |            17.612 |           1.76 |           9:19:00 |     4     0     0   100 |
|    RUNE/BUSD |      3 |           3.65 |          10.94 |            16.422 |           1.64 |          10:30:00 |     3     0     0   100 |
|     BEL/BUSD |      2 |           5.47 |          10.94 |            16.419 |           1.64 |    1 day, 1:45:00 |     2     0     0   100 |
|   CREAM/BUSD |      5 |           2.17 |          10.86 |            16.305 |           1.63 |  5 days, 19:39:00 |     4     0     1  80.0 |
|   AERGO/BUSD |      2 |           5.28 |          10.56 |            15.862 |           1.59 |          10:08:00 |     2     0     0   100 |
|     ANT/BUSD |      2 |           5.25 |          10.49 |            15.753 |           1.58 |  5 days, 15:22:00 |     2     0     0   100 |
|    COMP/BUSD |      3 |           3.05 |           9.16 |            13.761 |           1.38 |   3 days, 2:30:00 |     3     0     0   100 |
|    LINA/BUSD |      3 |           2.99 |           8.98 |            13.479 |           1.35 |           7:30:00 |     3     0     0   100 |
|    ATOM/BUSD |      3 |           2.83 |           8.49 |            12.750 |           1.28 |          11:20:00 |     3     0     0   100 |
|     UFT/BUSD |      2 |           4.17 |           8.34 |            12.524 |           1.25 |    1 day, 2:00:00 |     2     0     0   100 |
|   1INCH/BUSD |      3 |           2.68 |           8.05 |            12.081 |           1.21 |   4 days, 9:00:00 |     3     0     0   100 |
|     KSM/BUSD |      2 |           3.90 |           7.79 |            11.704 |           1.17 |           8:15:00 |     2     0     0   100 |
|     TKO/BUSD |      2 |           3.81 |           7.62 |            11.446 |           1.14 |          11:52:00 |     2     0     0   100 |
|    HARD/BUSD |      3 |           2.43 |           7.30 |            10.960 |           1.10 |          12:00:00 |     3     0     0   100 |
|     AVA/BUSD |      1 |           7.18 |           7.18 |            10.782 |           1.08 |   1 day, 13:45:00 |     1     0     0   100 |
|      AR/BUSD |      3 |           2.35 |           7.05 |            10.584 |           1.06 |           5:55:00 |     3     0     0   100 |
|    CTSI/BUSD |      2 |           3.52 |           7.03 |            10.562 |           1.06 |  2 days, 10:30:00 |     2     0     0   100 |
|     GTC/BUSD |      2 |           3.44 |           6.87 |            10.321 |           1.03 |  3 days, 17:22:00 |     2     0     0   100 |
|      IQ/BUSD |      2 |           3.39 |           6.78 |            10.187 |           1.02 |  2 days, 21:22:00 |     2     0     0   100 |
|     FIL/BUSD |      1 |           6.60 |           6.60 |             9.913 |           0.99 |    1 day, 7:15:00 |     1     0     0   100 |
|   SUPER/BUSD |      2 |           3.29 |           6.59 |             9.893 |           0.99 |  3 days, 14:15:00 |     2     0     0   100 |
|    POLS/BUSD |      2 |           2.93 |           5.86 |             8.802 |           0.88 |          15:30:00 |     2     0     0   100 |
|    PROM/BUSD |      2 |           2.73 |           5.47 |             8.206 |           0.82 |           5:08:00 |     2     0     0   100 |
|     DGB/BUSD |      4 |           1.36 |           5.45 |             8.178 |           0.82 |   1 day, 14:00:00 |     3     0     1  75.0 |
|    LUNA/BUSD |      2 |           2.67 |           5.33 |             8.003 |           0.80 |           4:15:00 |     2     0     0   100 |
|     PHA/BUSD |      1 |           5.30 |           5.30 |             7.953 |           0.80 |  2 days, 22:30:00 |     1     0     0   100 |
|     ENJ/BUSD |      2 |           2.61 |           5.21 |             7.824 |           0.78 |    1 day, 4:00:00 |     2     0     0   100 |
|     HOT/BUSD |      2 |           2.44 |           4.89 |             7.341 |           0.73 |           3:38:00 |     2     0     0   100 |
|    DEGO/BUSD |      2 |           2.44 |           4.88 |             7.330 |           0.73 |  5 days, 20:22:00 |     2     0     0   100 |
|    STMX/BUSD |      1 |           4.66 |           4.66 |             7.002 |           0.70 |          13:45:00 |     1     0     0   100 |
|   WAVES/BUSD |      1 |           4.66 |           4.66 |             7.000 |           0.70 |           4:30:00 |     1     0     0   100 |
|    IDEX/BUSD |      1 |           4.61 |           4.61 |             6.922 |           0.69 |   4 days, 0:45:00 |     1     0     0   100 |
|     ZIL/BUSD |      1 |           4.60 |           4.60 |             6.901 |           0.69 |           2:30:00 |     1     0     0   100 |
|    EGLD/BUSD |      2 |           2.25 |           4.51 |             6.765 |           0.68 |          18:30:00 |     2     0     0   100 |
|     SNX/BUSD |      2 |           2.23 |           4.46 |             6.693 |           0.67 |           5:38:00 |     2     0     0   100 |
|     GRT/BUSD |      1 |           3.89 |           3.89 |             5.848 |           0.58 |           2:30:00 |     1     0     0   100 |
|     BTT/BUSD |      1 |           3.32 |           3.32 |             4.991 |           0.50 |           2:30:00 |     1     0     0   100 |
|    KEEP/BUSD |      3 |           1.08 |           3.23 |             4.848 |           0.48 |  3 days, 16:40:00 |     2     0     1  66.7 |
|    DOGE/BUSD |      1 |           2.95 |           2.95 |             4.435 |           0.44 |          10:15:00 |     1     0     0   100 |
|     CRV/BUSD |      1 |           2.91 |           2.91 |             4.364 |           0.44 |  12 days, 0:15:00 |     1     0     0   100 |
|    PERP/BUSD |      4 |           0.70 |           2.82 |             4.230 |           0.42 |   1 day, 13:26:00 |     3     0     1  75.0 |
|     TVK/BUSD |      1 |           2.82 |           2.82 |             4.229 |           0.42 |    1 day, 2:45:00 |     1     0     0   100 |
|    DODO/BUSD |      1 |           2.81 |           2.81 |             4.226 |           0.42 |    1 day, 1:00:00 |     1     0     0   100 |
|    MANA/BUSD |      1 |           2.77 |           2.77 |             4.167 |           0.42 |   2 days, 9:45:00 |     1     0     0   100 |
|     SXP/BUSD |      1 |           2.76 |           2.76 |             4.141 |           0.41 |           1:00:00 |     1     0     0   100 |
|     INJ/BUSD |      1 |           2.34 |           2.34 |             3.508 |           0.35 |  2 days, 18:45:00 |     1     0     0   100 |
|     FTM/BUSD |      1 |           2.33 |           2.33 |             3.494 |           0.35 |   3 days, 1:30:00 |     1     0     0   100 |
|    NANO/BUSD |      1 |           2.30 |           2.30 |             3.459 |           0.35 |   2 days, 4:45:00 |     1     0     0   100 |
|     SKL/BUSD |      1 |           2.30 |           2.30 |             3.456 |           0.35 |    1 day, 2:45:00 |     1     0     0   100 |
|    LINK/BUSD |      1 |           2.03 |           2.03 |             3.050 |           0.31 |   3 days, 3:30:00 |     1     0     0   100 |
|    BAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    BZRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     CTK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     DOT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    IOST/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     KNC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     LIT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|   MATIC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     MDX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    NEAR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     ONE/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    POND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    REEF/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     RSR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    SAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    SHIB/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     SOL/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     SRM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|   SUSHI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|   THETA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     WRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     XRP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     XVG/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     YFI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     ZEC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     MIR/BUSD |      3 |          -1.09 |          -3.26 |            -4.899 |          -0.49 |  3 days, 11:45:00 |     2     0     1  66.7 |
|   ALICE/BUSD |      6 |          -0.98 |          -5.91 |            -8.868 |          -0.89 |          20:05:00 |     5     0     1  83.3 |
|    AAVE/BUSD |      4 |          -1.83 |          -7.32 |           -10.994 |          -1.10 |   4 days, 0:15:00 |     3     0     1  75.0 |
|    COTI/BUSD |      4 |          -1.91 |          -7.63 |           -11.453 |          -1.15 |    1 day, 2:38:00 |     3     0     1  75.0 |
|   FRONT/BUSD |      3 |          -4.03 |         -12.10 |           -18.164 |          -1.82 |   1 day, 13:30:00 |     2     0     1  66.7 |
|     CVP/BUSD |      3 |          -4.58 |         -13.74 |           -20.624 |          -2.06 |  4 days, 12:55:00 |     2     0     1  66.7 |
|    AVAX/BUSD |      3 |          -4.75 |         -14.26 |           -21.407 |          -2.14 |          17:10:00 |     2     0     1  66.7 |
|   FORTH/BUSD |      3 |          -4.79 |         -14.38 |           -21.586 |          -2.16 |          10:25:00 |     2     0     1  66.7 |
|    BAKE/BUSD |      2 |          -8.21 |         -16.41 |           -24.643 |          -2.46 |  2 days, 15:30:00 |     1     0     1  50.0 |
|   OCEAN/BUSD |      2 |          -8.66 |         -17.33 |           -26.015 |          -2.60 |          18:52:00 |     1     0     1  50.0 |
|     BCH/BUSD |      3 |          -5.88 |         -17.63 |           -26.465 |          -2.65 |   3 days, 6:55:00 |     1     0     2  33.3 |
|     XVS/BUSD |      2 |          -9.07 |         -18.15 |           -27.249 |          -2.72 |          12:00:00 |     1     0     1  50.0 |
|     SFP/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 | 10 days, 12:45:00 |     0     0     1     0 |
|     TLM/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |          14:30:00 |     0     0     1     0 |
|     TWT/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |           0:15:00 |     0     0     1     0 |
|     UNI/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |  5 days, 21:15:00 |     0     0     1     0 |
|     XTZ/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |   2 days, 7:00:00 |     0     0     1     0 |
|     ICP/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |  6 days, 23:00:00 |     0     0     1     0 |
|    DASH/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |    1 day, 2:00:00 |     0     0     1     0 |
|     MKR/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |  14 days, 7:15:00 |     0     0     1     0 |
|    IOTX/BUSD |      4 |          -8.31 |         -33.25 |           -49.926 |          -4.99 |   1 day, 20:56:00 |     2     0     2  50.0 |
|        TOTAL |    192 |           0.95 |         181.88 |           273.099 |          27.31 |   1 day, 21:14:00 |   165     0    27  85.9 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |     164 |    164     0     0   100 |           4.06 |         665.31 |           998.97  |         110.89 |
|          stop_loss |      23 |      0     0    23     0 |         -20.16 |        -463.68 |          -696.21  |         -77.28 |
|         force_sell |       5 |      1     0     4  20.0 |          -3.95 |         -19.75 |           -29.661 |          -3.29 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
| FRONT/BUSD |      1 |           1.05 |           1.05 |             1.577 |           0.16 |   1 day, 4:45:00 |     1     0     0   100 |
|   BCH/BUSD |      1 |          -0.08 |          -0.08 |            -0.121 |          -0.01 | 3 days, 14:00:00 |     0     0     1     0 |
|   DGB/BUSD |      1 |          -3.12 |          -3.12 |            -4.691 |          -0.47 | 3 days, 13:30:00 |     0     0     1     0 |
|  KEEP/BUSD |      1 |          -7.98 |          -7.98 |           -11.977 |          -1.20 | 7 days, 15:30:00 |     0     0     1     0 |
|   MIR/BUSD |      1 |          -9.62 |          -9.62 |           -14.449 |          -1.44 | 9 days, 12:30:00 |     0     0     1     0 |
|      TOTAL |      5 |          -3.95 |         -19.75 |           -29.661 |          -2.97 |  5 days, 2:27:00 |     1     0     4  20.0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-08-01 00:00:00 |
| Backtesting to         | 2021-10-01 00:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 192 / 3.15          |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1273.099 BUSD       |
| Absolute profit        | 273.099 BUSD        |
| Total profit %         | 27.31%              |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 28800.000 BUSD      |
|                        |                     |
| Best Pair              | ATA/BUSD 36.25%     |
| Worst Pair             | IOTX/BUSD -33.25%   |
| Best trade             | LTC/BUSD 21.12%     |
| Worst trade            | PERP/BUSD -20.16%   |
| Best day               | 61.836 BUSD         |
| Worst day              | -174.106 BUSD       |
| Days win/draw/lose     | 39 / 11 / 12        |
| Avg. Duration Winners  | 1 day, 11:14:00     |
| Avg. Duration Loser    | 4 days, 10:18:00    |
| Rejected Buy signals   | 574841              |
|                        |                     |
| Min balance            | 1007.211 BUSD       |
| Max balance            | 1523.663 BUSD       |
| Drawdown               | 168.56%             |
| Drawdown               | 253.095 BUSD        |
| Drawdown high          | 523.663 BUSD        |
| Drawdown low           | 270.568 BUSD        |
| Drawdown Start         | 2021-09-07 01:15:00 |
| Drawdown End           | 2021-09-26 07:30:00 |
| Market change          | 64.39%              |
================================================

Result for strategy Apollo11_3
============================================================= BACKTESTING REPORT =============================================================
|         Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |      Avg Duration |   Win  Draw  Loss  Win% |
|--------------+--------+----------------+----------------+-------------------+----------------+-------------------+-------------------------|
|   CREAM/BUSD |      5 |           7.69 |          38.44 |            57.710 |           5.77 |  2 days, 19:33:00 |     5     0     0   100 |
|     ANT/BUSD |      4 |           6.26 |          25.06 |            37.623 |           3.76 |   2 days, 6:38:00 |     4     0     0   100 |
|    DEXE/BUSD |      6 |           3.55 |          21.27 |            31.939 |           3.19 |    1 day, 4:02:00 |     6     0     0   100 |
|     AXS/BUSD |      5 |           4.02 |          20.08 |            30.157 |           3.02 |          20:09:00 |     5     0     0   100 |
|    ATOM/BUSD |      4 |           4.65 |          18.61 |            27.948 |           2.79 |          11:30:00 |     4     0     0   100 |
|    ALGO/BUSD |      5 |           3.41 |          17.05 |            25.606 |           2.56 |          13:51:00 |     5     0     0   100 |
|   AERGO/BUSD |      7 |           2.15 |          15.04 |            22.581 |           2.26 |    1 day, 9:19:00 |     7     0     0   100 |
|    AAVE/BUSD |      4 |           3.69 |          14.77 |            22.182 |           2.22 |   5 days, 8:22:00 |     4     0     0   100 |
|    LUNA/BUSD |      4 |           3.53 |          14.13 |            21.217 |           2.12 |          14:56:00 |     4     0     0   100 |
|    RUNE/BUSD |      4 |           3.41 |          13.63 |            20.465 |           2.05 |           9:08:00 |     4     0     0   100 |
|     BEL/BUSD |      3 |           4.40 |          13.21 |            19.834 |           1.98 |    1 day, 5:45:00 |     3     0     0   100 |
|     EPS/BUSD |      4 |           3.06 |          12.26 |            18.405 |           1.84 |           7:22:00 |     4     0     0   100 |
|     GRT/BUSD |      3 |           3.75 |          11.25 |            16.885 |           1.69 |          14:05:00 |     3     0     0   100 |
|    DEGO/BUSD |      3 |           3.69 |          11.06 |            16.614 |           1.66 |          18:25:00 |     3     0     0   100 |
|    PROM/BUSD |      4 |           2.69 |          10.76 |            16.162 |           1.62 |    1 day, 2:49:00 |     4     0     0   100 |
|     TKO/BUSD |      3 |           3.58 |          10.75 |            16.141 |           1.61 |   1 day, 23:50:00 |     3     0     0   100 |
|    CTSI/BUSD |      4 |           2.66 |          10.64 |            15.983 |           1.60 |    1 day, 0:56:00 |     4     0     0   100 |
|   FRONT/BUSD |      3 |           3.47 |          10.42 |            15.645 |           1.56 |          23:30:00 |     3     0     0   100 |
|    IOST/BUSD |      3 |           3.45 |          10.36 |            15.557 |           1.56 |          12:45:00 |     3     0     0   100 |
|    AVAX/BUSD |      3 |           3.31 |           9.92 |            14.891 |           1.49 |           6:15:00 |     3     0     0   100 |
|    COMP/BUSD |      3 |           3.20 |           9.60 |            14.415 |           1.44 |  2 days, 12:15:00 |     3     0     0   100 |
|    HARD/BUSD |      1 |           9.10 |           9.10 |            13.663 |           1.37 |   3 days, 7:00:00 |     1     0     0   100 |
|   ALPHA/BUSD |      2 |           4.43 |           8.86 |            13.296 |           1.33 |          13:00:00 |     2     0     0   100 |
|   SUPER/BUSD |      3 |           2.92 |           8.75 |            13.145 |           1.31 |  2 days, 20:05:00 |     3     0     0   100 |
|     FIO/BUSD |      3 |           2.83 |           8.48 |            12.736 |           1.27 |   2 days, 0:30:00 |     3     0     0   100 |
|    SHIB/BUSD |      2 |           4.13 |           8.26 |            12.398 |           1.24 |          19:52:00 |     2     0     0   100 |
|     PHA/BUSD |      2 |           4.05 |           8.10 |            12.160 |           1.22 |  2 days, 12:30:00 |     2     0     0   100 |
|     GTC/BUSD |      3 |           2.49 |           7.48 |            11.229 |           1.12 |   2 days, 5:00:00 |     3     0     0   100 |
|     BTT/BUSD |      2 |           3.32 |           6.63 |             9.956 |           1.00 |          14:15:00 |     2     0     0   100 |
|     UFT/BUSD |      2 |           3.27 |           6.53 |             9.807 |           0.98 |    1 day, 9:00:00 |     2     0     0   100 |
|     CRV/BUSD |      2 |           3.26 |           6.52 |             9.796 |           0.98 |           3:08:00 |     2     0     0   100 |
|    LINA/BUSD |      2 |           3.15 |           6.29 |             9.447 |           0.94 |           8:15:00 |     2     0     0   100 |
|     FXS/BUSD |      3 |           2.05 |           6.16 |             9.244 |           0.92 |   4 days, 0:00:00 |     3     0     0   100 |
|     FIL/BUSD |      2 |           3.04 |           6.07 |             9.120 |           0.91 |  3 days, 20:30:00 |     2     0     0   100 |
|    DATA/BUSD |      2 |           2.91 |           5.81 |             8.724 |           0.87 |   3 days, 8:52:00 |     2     0     0   100 |
|    POLS/BUSD |      2 |           2.88 |           5.77 |             8.662 |           0.87 |          10:45:00 |     2     0     0   100 |
|    DODO/BUSD |      2 |           2.73 |           5.46 |             8.199 |           0.82 |          22:22:00 |     2     0     0   100 |
|    POND/BUSD |      2 |           2.61 |           5.23 |             7.851 |           0.79 |           2:45:00 |     2     0     0   100 |
|   AUDIO/BUSD |      2 |           2.44 |           4.88 |             7.331 |           0.73 |           5:22:00 |     2     0     0   100 |
|     SOL/BUSD |      1 |           4.66 |           4.66 |             6.994 |           0.70 |          14:45:00 |     1     0     0   100 |
|     ZIL/BUSD |      1 |           4.60 |           4.60 |             6.901 |           0.69 |           2:30:00 |     1     0     0   100 |
|     ONE/BUSD |      1 |           4.57 |           4.57 |             6.865 |           0.69 |  2 days, 10:45:00 |     1     0     0   100 |
|    NEAR/BUSD |      1 |           4.12 |           4.12 |             6.181 |           0.62 |           7:30:00 |     1     0     0   100 |
|     XVS/BUSD |      2 |           2.05 |           4.10 |             6.156 |           0.62 |    1 day, 5:00:00 |     2     0     0   100 |
|    BZRX/BUSD |      1 |           3.75 |           3.75 |             5.627 |           0.56 |           4:45:00 |     1     0     0   100 |
|    DASH/BUSD |      1 |           3.34 |           3.34 |             5.018 |           0.50 |           6:00:00 |     1     0     0   100 |
|     DGB/BUSD |      3 |           1.10 |           3.29 |             4.939 |           0.49 |   1 day, 20:00:00 |     2     0     1  66.7 |
|     ATA/BUSD |     10 |           0.32 |           3.19 |             4.795 |           0.48 |          18:27:00 |     9     0     1  90.0 |
|     KSM/BUSD |      1 |           3.14 |           3.14 |             4.712 |           0.47 |           5:15:00 |     1     0     0   100 |
|   OCEAN/BUSD |      1 |           2.83 |           2.83 |             4.255 |           0.43 |           8:00:00 |     1     0     0   100 |
|    PERP/BUSD |      4 |           0.70 |           2.82 |             4.230 |           0.42 |   1 day, 13:26:00 |     3     0     1  75.0 |
|     ZEC/BUSD |      1 |           2.80 |           2.80 |             4.198 |           0.42 |    1 day, 5:15:00 |     1     0     0   100 |
|     SXP/BUSD |      1 |           2.76 |           2.76 |             4.141 |           0.41 |           1:00:00 |     1     0     0   100 |
|     ENJ/BUSD |      1 |           2.70 |           2.70 |             4.047 |           0.40 |   2 days, 4:30:00 |     1     0     0   100 |
|   THETA/BUSD |      1 |           2.55 |           2.55 |             3.826 |           0.38 |  2 days, 16:15:00 |     1     0     0   100 |
|    KEEP/BUSD |      1 |           2.44 |           2.44 |             3.670 |           0.37 |           1:15:00 |     1     0     0   100 |
|     INJ/BUSD |      1 |           2.34 |           2.34 |             3.508 |           0.35 |  2 days, 18:45:00 |     1     0     0   100 |
|    EGLD/BUSD |      1 |           2.33 |           2.33 |             3.493 |           0.35 |           2:15:00 |     1     0     0   100 |
|    REEF/BUSD |      1 |           2.21 |           2.21 |             3.317 |           0.33 |          15:30:00 |     1     0     0   100 |
|     HOT/BUSD |      1 |           2.04 |           2.04 |             3.058 |           0.31 |           0:15:00 |     1     0     0   100 |
|    LINK/BUSD |      1 |           2.03 |           2.03 |             3.050 |           0.31 |   3 days, 3:30:00 |     1     0     0   100 |
|      AR/BUSD |      1 |           2.01 |           2.01 |             3.017 |           0.30 |           0:30:00 |     1     0     0   100 |
|    IDEX/BUSD |      1 |           1.73 |           1.73 |             2.592 |           0.26 |   4 days, 0:15:00 |     1     0     0   100 |
| AUCTION/BUSD |      7 |           0.21 |           1.49 |             2.238 |           0.22 |   1 day, 14:02:00 |     6     0     1  85.7 |
|     XVG/BUSD |      1 |           1.37 |           1.37 |             2.062 |           0.21 |  5 days, 17:45:00 |     1     0     0   100 |
|      IQ/BUSD |      1 |           1.01 |           1.01 |             1.520 |           0.15 |   5 days, 9:00:00 |     1     0     0   100 |
|    MANA/BUSD |      1 |           0.82 |           0.82 |             1.227 |           0.12 |   2 days, 4:00:00 |     1     0     0   100 |
|     SKL/BUSD |      1 |           0.49 |           0.49 |             0.740 |           0.07 |  3 days, 23:15:00 |     1     0     0   100 |
|     AVA/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    BAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     CTK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     DOT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     FTM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     KNC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     LIT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     LTC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|   MATIC/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     MDX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     MKR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    NANO/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     RSR/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    SAND/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     SFP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     SNX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     SRM/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|    STMX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|   SUSHI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     TVK/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     TWT/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     WRX/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     XRP/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|     YFI/BUSD |      0 |           0.00 |           0.00 |             0.000 |           0.00 |              0:00 |     0     0     0     0 |
|   FORTH/BUSD |      3 |          -0.71 |          -2.12 |            -3.176 |          -0.32 |  2 days, 11:35:00 |     2     0     1  66.7 |
|   ALICE/BUSD |      7 |          -0.40 |          -2.82 |            -4.227 |          -0.42 |    1 day, 6:06:00 |     6     0     1  85.7 |
|     MIR/BUSD |      2 |          -3.81 |          -7.62 |           -11.447 |          -1.14 |  4 days, 19:08:00 |     1     0     1  50.0 |
|    DOCK/BUSD |      4 |          -2.13 |          -8.50 |           -12.763 |          -1.28 |    1 day, 9:19:00 |     3     0     1  75.0 |
|    COTI/BUSD |      3 |          -4.04 |         -12.13 |           -18.214 |          -1.82 |    1 day, 7:05:00 |     2     0     1  66.7 |
|     ICP/BUSD |      2 |          -7.73 |         -15.46 |           -23.207 |          -2.32 |   3 days, 5:08:00 |     1     0     1  50.0 |
|    IOTX/BUSD |      3 |          -5.47 |         -16.41 |           -24.636 |          -2.46 |   1 day, 21:15:00 |     2     0     1  66.7 |
|     CVP/BUSD |      4 |          -4.18 |         -16.73 |           -25.121 |          -2.51 |   4 days, 0:52:00 |     3     0     1  75.0 |
|     BCH/BUSD |      3 |          -5.88 |         -17.63 |           -26.465 |          -2.65 |   3 days, 6:55:00 |     1     0     2  33.3 |
|   WAVES/BUSD |      2 |          -8.98 |         -17.96 |           -26.961 |          -2.70 |          13:30:00 |     1     0     1  50.0 |
|    BAKE/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |  4 days, 17:30:00 |     0     0     1     0 |
|    DOGE/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 | 17 days, 22:15:00 |     0     0     1     0 |
|     TLM/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |          14:30:00 |     0     0     1     0 |
|     UNI/BUSD |      1 |         -20.16 |         -20.16 |           -30.270 |          -3.03 |  5 days, 21:15:00 |     0     0     1     0 |
|   1INCH/BUSD |      6 |          -4.61 |         -27.68 |           -41.564 |          -4.16 |          11:00:00 |     4     0     2  66.7 |
|     XTZ/BUSD |      2 |         -20.16 |         -40.32 |           -60.540 |          -6.05 |   3 days, 1:38:00 |     0     0     2     0 |
|        TOTAL |    218 |           1.17 |         254.22 |           381.709 |          38.17 |   1 day, 15:50:00 |   195     0    23  89.4 |
======================================================= SELL REASON STATS ========================================================
|        Sell Reason |   Sells |   Win  Draws  Loss  Win% |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |
|--------------------+---------+--------------------------+----------------+----------------+-------------------+----------------|
| trailing_stop_loss |     194 |    194     0     0   100 |           3.39 |         656.93 |           986.385 |         109.49 |
|          stop_loss |      19 |      0     0    19     0 |         -20.16 |        -383.04 |          -575.13  |         -63.84 |
|         force_sell |       5 |      1     0     4  20.0 |          -3.94 |         -19.68 |           -29.545 |          -3.28 |
========================================================= LEFT OPEN TRADES REPORT =========================================================
|       Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |     Avg Duration |   Win  Draw  Loss  Win% |
|------------+--------+----------------+----------------+-------------------+----------------+------------------+-------------------------|
| FRONT/BUSD |      1 |           1.05 |           1.05 |             1.577 |           0.16 |   1 day, 4:45:00 |     1     0     0   100 |
|   BCH/BUSD |      1 |          -0.08 |          -0.08 |            -0.121 |          -0.01 | 3 days, 14:00:00 |     0     0     1     0 |
|   DGB/BUSD |      1 |          -3.12 |          -3.12 |            -4.691 |          -0.47 | 3 days, 13:30:00 |     0     0     1     0 |
| FORTH/BUSD |      1 |          -7.90 |          -7.90 |           -11.861 |          -1.19 | 6 days, 17:00:00 |     0     0     1     0 |
|   MIR/BUSD |      1 |          -9.62 |          -9.62 |           -14.449 |          -1.44 | 9 days, 12:30:00 |     0     0     1     0 |
|      TOTAL |      5 |          -3.94 |         -19.68 |           -29.545 |          -2.95 | 4 days, 21:57:00 |     1     0     4  20.0 |
=============== SUMMARY METRICS ================
| Metric                 | Value               |
|------------------------+---------------------|
| Backtesting from       | 2021-08-01 00:00:00 |
| Backtesting to         | 2021-10-01 00:00:00 |
| Max open trades        | 6                   |
|                        |                     |
| Total/Daily Avg Trades | 218 / 3.57          |
| Starting balance       | 1000.000 BUSD       |
| Final balance          | 1381.709 BUSD       |
| Absolute profit        | 381.709 BUSD        |
| Total profit %         | 38.17%              |
| Avg. stake amount      | 150.000 BUSD        |
| Total trade volume     | 32700.000 BUSD      |
|                        |                     |
| Best Pair              | CREAM/BUSD 38.44%   |
| Worst Pair             | XTZ/BUSD -40.32%    |
| Best trade             | CREAM/BUSD 21.08%   |
| Worst trade            | PERP/BUSD -20.16%   |
| Best day               | 51.176 BUSD         |
| Worst day              | -114.922 BUSD       |
| Days win/draw/lose     | 48 / 5 / 9          |
| Avg. Duration Winners  | 1 day, 8:49:00      |
| Avg. Duration Loser    | 4 days, 3:22:00     |
| Rejected Buy signals   | 576050              |
|                        |                     |
| Min balance            | 1007.211 BUSD       |
| Max balance            | 1589.652 BUSD       |
| Drawdown               | 140.25%             |
| Drawdown               | 210.590 BUSD        |
| Drawdown high          | 589.652 BUSD        |
| Drawdown low           | 379.063 BUSD        |
| Drawdown Start         | 2021-09-07 12:45:00 |
| Drawdown End           | 2021-09-26 07:30:00 |
| Market change          | 64.39%              |
================================================

2021-08-01 00:00:00 -> 2021-10-01 00:00:00 | Max open trades : 6
======================================================================== STRATEGY SUMMARY ========================================================================
|   Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BUSD |   Tot Profit % |    Avg Duration |   Win  Draw  Loss  Win% |              Drawdown |
|------------+--------+----------------+----------------+-------------------+----------------+-----------------+-------------------------+-----------------------|
|   Apollo11 |    192 |           0.95 |         181.88 |           273.099 |          27.31 | 1 day, 21:14:00 |   165     0    27  85.9 | 253.095 BUSD  168.56% |
| Apollo11_3 |    218 |           1.17 |         254.22 |           381.709 |          38.17 | 1 day, 15:50:00 |   195     0    23  89.4 | 210.590 BUSD  140.25% |
==================================================================================================================================================================
```